### PR TITLE
feat: integrate Flask routes and remove old generic shop.html

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,51 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+
+app = Flask(__name__)
+app.secret_key = 'your-secret-key-change-this'
+
+# ── Main Pages ──────────────────────────────────────────
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/brew')
+def brew():
+    return render_template('brew.html')
+
+@app.route('/profile')
+def profile():
+    return render_template('profile.html')
+
+@app.route('/social')
+def social():
+    return render_template('social.html')
+
+# ── Shop Pages ───────────────────────────────────────────
+@app.route('/shop')
+def shop():
+    return render_template('shop.html')
+
+@app.route('/shop/blacklist')
+def shop_blacklist():
+    return render_template('shop-blacklist.html')
+
+@app.route('/shop/laveen')
+def shop_laveen():
+    return render_template('shop-laveen.html')
+
+@app.route('/shop/venn')
+def shop_venn():
+    return render_template('shop-venn.html')
+
+# ── Auth Pages ───────────────────────────────────────────
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    return render_template('login.html')
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/brew.html
+++ b/templates/brew.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Brew Map | Coffee Social Hub</title>
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/brew.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/brew.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -14,15 +14,15 @@
 <!-- NAVBAR -->
 <nav class="navbar navbar-expand-lg">
     <div class="container">
-        <a class="navbar-brand" href="index.html">Coffee Social Hub</a>
+        <a class="navbar-brand" href="{{ url_for('index') }}">Coffee Social Hub</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navMenu">
             <ul class="navbar-nav ms-auto align-items-center gap-2">
-                <li class="nav-item"><a class="nav-link active" href="brew.html">Brew Map</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Social Grounds</a></li>
-                <li class="nav-item"><a class="btn btn-nav" href="#">Login / Sign Up</a></li>
+                <li class="nav-item"><a class="nav-link active" href="{{ url_for('brew') }}">Brew Map</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('social') }}">Social Grounds</a></li>
+                <li class="nav-item"><a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a></li>
             </ul>
         </div>
     </div>
@@ -67,7 +67,7 @@
                 <p><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.8</p>
                 <p><i class="bi bi-clock" style="color:var(--caramel)"></i> 7:00 AM – 3:00 PM</p>
                 <div class="mt-2"><span class="shop-tag">Cold Brew</span></div>
-                <a href="shop-blacklist.html" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
+                <a href="{{ url_for('shop_blacklist') }}" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
             </div>
         </div>
 
@@ -81,7 +81,7 @@
                 <p><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.6</p>
                 <p><i class="bi bi-clock" style="color:var(--caramel)"></i> 6:30 AM – 2:30 PM</p>
                 <div class="mt-2"><span class="shop-tag">Pour Over</span></div>
-                <a href="shop-laveen.html" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
+                <a href="{{ url_for('shop_laveen') }}" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
             </div>
         </div>
 
@@ -95,7 +95,7 @@
                 <p><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.7</p>
                 <p><i class="bi bi-clock" style="color:var(--caramel)"></i> 7:00 AM – 4:00 PM</p>
                 <div class="mt-2"><span class="shop-tag">Pet Friendly</span></div>
-                <a href="shop-venn.html" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
+                <a href="{{ url_for('shop_venn') }}" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
             </div>
         </div>
 
@@ -106,12 +106,12 @@
 <footer class="mt-5">
     <div class="container d-flex flex-wrap justify-content-between align-items-center gap-3">
         <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS3403 / CITS5505 Group Project · UWA 2025</span>
+        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
     </div>
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="js/brew.js"></script> 
+<script src="{{ url_for('static', filename='js/brew.js') }}"></script> 
 </body>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Coffee Social Hub</title>
-    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
@@ -15,15 +15,15 @@
     <!-- NAVBAR -->
     <nav class="navbar navbar-expand-lg">
         <div class="container">
-            <a class="navbar-brand" href="index.html">Coffee Social Hub</a>
+            <a class="navbar-brand" href="{{ url_for('index') }}">Coffee Social Hub</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navMenu">
                 <ul class="navbar-nav ms-auto align-items-center gap-2">
-                    <li class="nav-item"><a class="nav-link" href="brew.html">Brew Map</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#">Social Grounds</a></li>
-                    <li class="nav-item"><a class="btn btn-nav" href="#">Login / Sign Up</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('brew') }}">Brew Map</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('social') }}">Social Grounds</a></li>
+                    <li class="nav-item"><a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a></li>
                 </ul>
             </div>
         </div>
@@ -44,7 +44,7 @@
                     </p>
                     <div class="hero-cta">
                         <a href="#" class="btn btn-primary-custom">Join as a Barista</a>
-                        <a href="brew.html" class="btn btn-ghost">See the Brew Map</a>
+                        <a href="{{ url_for('brew') }}" class="btn btn-ghost">See the Brew Map</a>
                     </div>
                 </div>
                 <div class="col-lg-6 hero-visual">
@@ -151,7 +151,7 @@
     <footer>
         <div class="container d-flex flex-wrap justify-content-between align-items-center gap-3">
             <span class="footer-brand">Coffee Social Hub</span>
-            <span class="footer-note">CITS3403 / CITS5505 Group Project · UWA 2025</span>
+            <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
         </div>
     </footer>
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -6,7 +6,7 @@
     <title>My Profile</title>
     
     <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/profile.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
 
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
@@ -18,10 +18,10 @@
         <div class="container">
             <a class="navbar-brand" href="landing.html">☕ Coffee Social Hub</a>
             <ul class="navbar-nav ms-auto gap-3">
-                <li><a class="nav-link" href="brew.html">Brew Map</a></li>
-                <li><a class="nav-link" href="#">Social Grounds</a></li>
-                <li><a class="btn btn-outline-nav" href="#">Log In</a></li>
-                <li><a class="btn btn-nav" href="#">Join Free</a></li>
+                <li><a class="nav-link" href="{{ url_for('brew') }}">Brew Map</a></li>
+                <li><a class="nav-link" href="{{ url_for('social') }}">Social Grounds</a></li>
+                <li><a class="btn btn-outline-nav" href="{{ url_for('login') }}">Log In</a></li>
+                <li><a class="btn btn-nav" href="{{ url_for('login') }}">Join Free</a></li>
             </ul>
         </div>
     </nav>

--- a/templates/shop-blacklist.html
+++ b/templates/shop-blacklist.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blacklist Coffee Roasters | Coffee Social Hub</title>
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/shop.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -14,15 +14,15 @@
 
 <nav class="navbar navbar-expand-lg">
     <div class="container">
-        <a class="navbar-brand" href="index.html">Coffee Social Hub</a>
+        <a class="navbar-brand" href="{{ url_for('index') }}">Coffee Social Hub</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navMenu">
             <ul class="navbar-nav ms-auto align-items-center gap-2">
-                <li class="nav-item"><a class="nav-link" href="brew.html">Brew Map</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Social Grounds</a></li>
-                <li class="nav-item"><a class="btn btn-nav" href="#">Login / Sign Up</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('brew') }}">Brew Map</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('social') }}">Social Grounds</a></li>
+                <li class="nav-item"><a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a></li>
             </ul>
         </div>
     </div>
@@ -31,7 +31,7 @@
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
-        <a href="brew.html" class="shop-back-link">
+        <a href="{{ url_for('brew') }}" class="shop-back-link">
             <span class="shop-back-arrow">←</span> Back to Brew Map
         </a>
         <div class="shop-hero-body">
@@ -184,7 +184,7 @@
                 </ul>
             </div>
 
-            <a href="brew.html" class="btn-primary-custom w-100 text-center d-block">
+            <a href="{{ url_for('brew') }}" class="btn-primary-custom w-100 text-center d-block">
                 Back to Brew Map
             </a>
         </div>
@@ -194,7 +194,7 @@
 <footer>
     <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
         <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS3403 / CITS5505 Group Project · UWA 2025</span>
+        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
     </div>
 </footer>
 

--- a/templates/shop-laveen.html
+++ b/templates/shop-laveen.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>La Veen Coffee | Coffee Social Hub</title>
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/shop.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -14,15 +14,15 @@
 
 <nav class="navbar navbar-expand-lg">
     <div class="container">
-        <a class="navbar-brand" href="index.html">Coffee Social Hub</a>
+        <a class="navbar-brand" href="{{ url_for('index') }}">Coffee Social Hub</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navMenu">
             <ul class="navbar-nav ms-auto align-items-center gap-2">
-                <li class="nav-item"><a class="nav-link" href="brew.html">Brew Map</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Social Grounds</a></li>
-                <li class="nav-item"><a class="btn btn-nav" href="#">Login / Sign Up</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('brew') }}">Brew Map</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('social') }}">Social Grounds</a></li>
+                <li class="nav-item"><a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a></li>
             </ul>
         </div>
     </div>
@@ -31,7 +31,7 @@
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
-        <a href="brew.html" class="shop-back-link">
+        <a href="{{ url_for('brew') }}" class="shop-back-link">
             <span class="shop-back-arrow">←</span> Back to Brew Map
         </a>
         <div class="shop-hero-body">
@@ -184,7 +184,7 @@
                 </ul>
             </div>
 
-            <a href="brew.html" class="btn-primary-custom w-100 text-center d-block">
+            <a href="{{ url_for('brew') }}" class="btn-primary-custom w-100 text-center d-block">
                 Back to Brew Map
             </a>
         </div>
@@ -194,7 +194,7 @@
 <footer>
     <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
         <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS3403 / CITS5505 Group Project · UWA 2025</span>
+        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
     </div>
 </footer>
 

--- a/templates/shop-venn.html
+++ b/templates/shop-venn.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Venn Coffee | Coffee Social Hub</title>
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/shop.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -14,15 +14,15 @@
 
 <nav class="navbar navbar-expand-lg">
     <div class="container">
-        <a class="navbar-brand" href="index.html">Coffee Social Hub</a>
+        <a class="navbar-brand" href="{{ url_for('index') }}">Coffee Social Hub</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navMenu">
             <ul class="navbar-nav ms-auto align-items-center gap-2">
-                <li class="nav-item"><a class="nav-link" href="brew.html">Brew Map</a></li>
-                <li class="nav-item"><a class="nav-link" href="#">Social Grounds</a></li>
-                <li class="nav-item"><a class="btn btn-nav" href="#">Login / Sign Up</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('brew') }}">Brew Map</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('social') }}">Social Grounds</a></li>
+                <li class="nav-item"><a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a></li>
             </ul>
         </div>
     </div>
@@ -31,7 +31,7 @@
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
-        <a href="brew.html" class="shop-back-link">
+        <a href="{{ url_for('brew') }}" class="shop-back-link">
             <span class="shop-back-arrow">←</span> Back to Brew Map
         </a>
         <div class="shop-hero-body">
@@ -189,7 +189,7 @@
                 </ul>
             </div>
 
-            <a href="brew.html" class="btn-primary-custom w-100 text-center d-block">
+            <a href="{{ url_for('brew') }}" class="btn-primary-custom w-100 text-center d-block">
                 Back to Brew Map
             </a>
         </div>
@@ -199,7 +199,7 @@
 <footer>
     <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
         <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS3403 / CITS5505 Group Project · UWA 2025</span>
+        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
     </div>
 </footer>
 

--- a/templates/shop.html
+++ b/templates/shop.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Shop Detail</title>
 
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/shop.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
 
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
@@ -18,7 +18,7 @@
     <div class="container">
         <a class="navbar-brand" href="landing.html">☕ Coffee Social Hub</a>
         <ul class="navbar-nav ms-auto gap-3">
-            <li><a class="nav-link" href="brew.html">Brew Map</a></li>
+            <li><a class="nav-link" href="{{ url_for('brew') }}">Brew Map</a></li>
             <li><a class="nav-link" href="feed.html">Social Grounds</a></li>
             <li><a class="btn btn-outline-nav" href="login.html">Log In</a></li>
             <li><a class="btn btn-nav" href="signup.html">Join Free</a></li>
@@ -32,7 +32,7 @@
     <div class="container hero-shop-content">
 
         <!-- Back breadcrumb -->
-        <a href="brew.html" class="shop-back-link">
+        <a href="{{ url_for('brew') }}" class="shop-back-link">
             <span class="shop-back-arrow">←</span> Back to Brew Map
         </a>
 
@@ -216,7 +216,7 @@
             </div>
 
             <!-- Back CTA -->
-            <a href="brew.html" class="btn-primary-custom w-100 text-center d-block">
+            <a href="{{ url_for('brew') }}" class="btn-primary-custom w-100 text-center d-block">
                 ← Back to Brew Map
             </a>
 


### PR DESCRIPTION
Changes in this PR:

Flask Integration:
- Added app.py with routes for all pages (index, brew, shop pages, profile, social, login, logout)
- Updated all HTML templates to use Flask url_for for static files and page links
- CSS links updated from href="css/style.css" to url_for('static') format
- JS links updated to url_for('static') format
- All page navigation links updated to url_for() format

Clean up:
- Removed old generic shop.html as individual shop pages already exist
- All templates now in templates/ folder
- All static files now in static/ folder

Flask routes available:
- / - index.html
- /brew - brew.html
- /shop/blacklist - shop-blacklist.html
- /shop/laveen - shop-laveen.html
- /shop/venn - shop-venn.html
- /profile - profile.html
- /social - social.html
- /login - login.html
- /logout - redirects to index