### PR TITLE
Fix root url to landing page and restrict navigation before login

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ users = {
 # ── Auth Routes ──────────────────────────────────────────
 @app.route("/")
 def index():
-    return redirect(url_for("login"))
+    return render_template("index.html")
 
 @app.route("/login", methods=["GET", "POST"])
 def login():

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,8 +22,10 @@
             </button>
             <div class="collapse navbar-collapse" id="navMenu">
                 <ul class="navbar-nav ms-auto align-items-center gap-2">
+                    {% if session.get("user") %}
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('brew') }}">Brew Map</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('social') }}">Social Grounds</a></li>
+                    {% endif %}
                     <li class="nav-item"><a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a></li>
                 </ul>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% block title %}Coffee Social Hub — Discover. Rate. Connect.{% endblock %}
+{% block title %}Coffee Social Hub - Discover. Rate. Connect.{% endblock %}
 {% block content %}
 
     <!-- HERO -->
@@ -16,8 +16,8 @@
                         earn Barista XP, and connect with coffee lovers near you.
                     </p>
                     <div class="hero-cta">
-                        <a href="{{ url_for('signup') }}" class="btn btn-primary-custom">Join as a Barista</a>
-                        <a href="{{ url_for('brew') }}" class="btn btn-ghost">See the Brew Map</a>
+                        <a href="{{ url_for('signup') if session.get('user') else url_for('login') }}" class="btn btn-primary-custom">Join as a Barista</a>
+                        <a href="{{ url_for('brew') if session.get('user') else url_for('login') }}" class="btn btn-ghost">See the Brew Map</a>
                     </div>
                 </div>
                 <div class="col-lg-6 hero-visual">
@@ -27,14 +27,14 @@
                         </div>
                         <div>
                             <div class="shop-name">Venn Coffee</div>
-                            <div class="shop-meta">4.7 stars · Pet friendly · Open now</div>
+                            <div class="shop-meta">4.7 stars - Pet friendly - Open now</div>
                         </div>
                     </div>
                     <div class="mock-card card-2">
                         <div class="avatar-sm">B</div>
                         <div>
                             <div class="shop-name">BrewEnthusiast</div>
-                            <div class="shop-meta">Level 4 Barista · 340 XP</div>
+                            <div class="shop-meta">Level 4 Barista - 340 XP</div>
                         </div>
                     </div>
                     <div class="mock-card card-3">
@@ -43,7 +43,7 @@
                         </div>
                         <div>
                             <div class="shop-name">3 cafes near you</div>
-                            <div class="shop-meta">Subiaco · Welshpool · CBD</div>
+                            <div class="shop-meta">Subiaco - Welshpool - CBD</div>
                         </div>
                     </div>
                     <div class="coffee-ring ring-a"></div>
@@ -114,11 +114,9 @@
                     </div>
                 </div>
                 <div class="text-center mt-5">
-                    <a href="{{ url_for('login') }}" class="btn btn-primary-custom">Get Started — It is Free</a>
+                    <a href="{{ url_for('landing') if session.get('user') else url_for('login') }}" class="btn btn-primary-custom">Get Started - It is Free</a>
                 </div>
             </div>
         </div>
     </section>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 {% endblock %}
-


### PR DESCRIPTION
Update the / route in app.py so http://127.0.0.1:5000 renders the landing page directly instead of redirecting users to the login page. 
Update the landing page so non-logged-in users cannot access protected sections directly. Hide Brew Map and Social Grounds from the navbar before login, and redirect the Join as a Barista, See the Brew Map, and Get Started buttons to the Login / Sign Up page unless a user session exists.