### PR TITLE
Fix: remove hardcoded footer from shop templates

### DIFF
--- a/templates/shop-blacklist.html
+++ b/templates/shop-blacklist.html
@@ -170,13 +170,6 @@
     </div>
 </main>
 
-<footer>
-    <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
-    </div>
-</footer>
-
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/shop-laveen.html
+++ b/templates/shop-laveen.html
@@ -170,13 +170,6 @@
     </div>
 </main>
 
-<footer>
-    <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
-    </div>
-</footer>
-
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/shop-venn.html
+++ b/templates/shop-venn.html
@@ -175,13 +175,6 @@
     </div>
 </main>
 
-<footer>
-    <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
-    </div>
-</footer>
-
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Delete duplicated footer HTML from shop-blacklist.html, shop-laveen.html, and shop-venn.html.