### PR TITLE
Fix: use 3-column brew grid and flexible cards

### DIFF
--- a/static/css/home.css
+++ b/static/css/home.css
@@ -65,25 +65,25 @@
         border-bottom: 2px solid rgba(196,122,43,0.15);
     }
 }
-/* Brew map cards grid — 2 columns */
+/* Brew map cards grid — 3 equal columns */
 .brew-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(3, 1fr);
     gap: 1rem;
     align-items: stretch;
 }
 
-/* Make last card fill remaining space */
-.brew-grid .shop-item:last-child:nth-child(odd) {
-    grid-column: 1 / -1;  /* span both columns */
-    max-width: 50%;        /* but only take half width */
+.brew-grid .shop-item {
+    display: flex;
 }
 
 .brew-grid .feature-card {
-    height: 200px;          /* fixed height not min-height */
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    width: 100%;
+    min-height: 200px;
+    height: auto;
 }
 
 .brew-grid h6 {


### PR DESCRIPTION
Change brew map layout from two to three equal columns and make shop items/cards flexible.

Replaced grid-template-columns with repeat(3, 1fr), removed the special-case last-child spanning rule, set .shop-item to display:flex, and converted .feature-card from a fixed height to width:100% with min-height:200px and height:auto so cards size consistently and respond to content.

Fixes #24 