### PR TITLE
feat: add local profile photo support across profile and feed

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -124,3 +124,42 @@
     font-weight: 700;
     border: 3px solid var(--latte);
 }
+
+.profile-avatar-image {
+    width: 90px;
+    height: 90px;
+    border-radius: 50%;
+    border: 3px solid var(--latte);
+    object-fit: cover;
+    display: none;
+}
+
+.profile-post-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.post-avatar-image,
+.post-avatar-placeholder {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.post-avatar-image {
+    object-fit: cover;
+}
+
+.post-avatar-placeholder {
+    background: var(--caramel);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.25rem;
+    font-weight: 700;
+}

--- a/static/css/social.css
+++ b/static/css/social.css
@@ -224,6 +224,17 @@ body{
     object-fit: cover;
 }
 
+.avatar-placeholder {
+    background: #c69c6d;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
 /* USER INFO */
 .user-info {
     display: flex;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -52,6 +52,35 @@ body {
     color: var(--latte) !important;
 }
 
+.nav-profile-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.nav-profile-avatar {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+.nav-profile-avatar .bi {
+    margin-right: 0;
+}
+
+.nav-profile-avatar img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+}
+
 .btn-nav {
     background: var(--caramel);
     color: #fff !important;

--- a/static/js/social.js
+++ b/static/js/social.js
@@ -59,6 +59,28 @@ function getRandomUser() {
     return users[Math.floor(Math.random() * users.length)];
 }
 
+const activeUser = typeof currentUser === "string" && currentUser.trim()
+    ? currentUser
+    : "User";
+
+function getSavedAvatar(username = activeUser) {
+    return localStorage.getItem(`profileAvatar:${username}`) || "";
+}
+
+function getDisplayAvatar(postData) {
+    if (postData.username === activeUser) return getSavedAvatar() || postData.avatar || "";
+    if (postData.avatar) return postData.avatar;
+    return "";
+}
+
+function avatarMarkup(username, avatar) {
+    if (avatar) {
+        return `<img class="avatar" src="${avatar}" alt="${username} profile photo">`;
+    }
+
+    return `<div class="avatar avatar-placeholder">${(username || "U").charAt(0).toUpperCase()}</div>`;
+}
+
 // ── INIT ─────────────────────────
 window.onload = function () {
     loadPosts();
@@ -99,22 +121,27 @@ function loadPosts() {
 // ── RENDER POST ─────────────────────────
 function renderPost(postData, prepend = false) {
     const feed = document.getElementById("feed");
+    const username = postData.username || "Anonymous";
+    const avatar = getDisplayAvatar(postData);
+    const postImage = postData.image
+        ? `<div class="post-image-wrapper">
+        <img src="${postData.image}" alt="Coffee post image">
+    </div>`
+        : "";
 
     const post = document.createElement("div");
     post.classList.add("post");
 
     post.innerHTML = `
     <div class="post-header">
-        <img class="avatar" src="${postData.avatar || ''}">
+        ${avatarMarkup(username, avatar)}
         <div class="user-info">
-            <strong>${postData.username || "Anonymous"}</strong>
+            <strong>${username}</strong>
             <span class="location">${postData.shop || ""}</span>
         </div>
     </div>
 
-    <div class="post-image-wrapper">
-        <img src="${postData.image || ''}">
-    </div>
+    ${postImage}
 
     <div class="post-actions">
         <button onclick="likePost('${postData.time}', this)">
@@ -123,7 +150,7 @@ function renderPost(postData, prepend = false) {
     </div>
 
     <div class="post-caption d-flex justify-content-between align-items-start">
-    <span><strong>${postData.username || "Anonymous"}</strong> ${postData.text || ""}</span>
+    <span><strong>${username}</strong> ${postData.text || ""}</span>
     <button onclick="deletePost('${postData.time}')" 
         style="border:none;background:none;color:var(--muted);font-size:0.8rem;cursor:pointer;">
         <i class="bi bi-trash"></i>
@@ -183,14 +210,12 @@ function addComment(e, postTime, input) {
 
         const commentText = input.value.trim();
         let posts = JSON.parse(localStorage.getItem("posts")) || [];
-        const user = getRandomUser();
-
         posts = posts.map(p => {
             if (p.time === postTime) {
                 if (!p.comments) p.comments = [];
 
                 p.comments.push({
-                    username: user.name,
+                    username: activeUser,
                     text: commentText,
                     time: new Date().toISOString()
                 });
@@ -270,11 +295,9 @@ function submitModalPost() {
     const reader = new FileReader();
 
     reader.onload = function (e) {
-        const user = getRandomUser();
-
         const postData = {
-            username: user.name,
-            avatar: user.avatar,
+            username: activeUser,
+            avatar: getSavedAvatar(),
             text,
             shop,
             image: e.target.result,

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,8 +26,11 @@
                 <ul class="navbar-nav ms-auto align-items-center gap-2">
                     {% if session.get("user") %}
     <li class="nav-item">
-        <a class="nav-link" href="{{ url_for('profile') }}">
-            <i class="bi bi-person-circle"></i> {{ session.get('user') }}
+        <a class="nav-link nav-profile-link" href="{{ url_for('profile') }}">
+            <span class="nav-profile-avatar" data-navbar-avatar>
+                <i class="bi bi-person-circle"></i>
+            </span>
+            <span>{{ session.get('user') }}</span>
         </a>
     </li>
     <li class="nav-item">
@@ -55,6 +58,24 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    {% if session.get("user") %}
+    <script>
+        (function() {
+            const currentUser = {{ session.get('user')|tojson }};
+            const avatar = localStorage.getItem(`profileAvatar:${currentUser}`);
+            const avatarSlot = document.querySelector('[data-navbar-avatar]');
+
+            function updateNavbarAvatar(avatarData) {
+                if (avatarData && avatarSlot) {
+                    avatarSlot.innerHTML = `<img src="${avatarData}" alt="${currentUser} profile photo">`;
+                }
+            }
+
+            updateNavbarAvatar(avatar);
+            window.updateNavbarAvatar = updateNavbarAvatar;
+        })();
+    </script>
+    {% endif %}
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -120,6 +120,7 @@
 
 {% block extra_js %}
 <script>
+    const currentUser = {{ session.get('user', 'User')|tojson }};
     const routes = {
         blacklist: "{{ url_for('shop_blacklist') }}",
         laveen: "{{ url_for('shop_laveen') }}",

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -18,13 +18,18 @@
     <!-- Profile Header -->
     <div class="profile-header d-flex align-items-center gap-4 mb-4">
         <div class="profile-avatar-wrapper">
-            <div class="profile-avatar-placeholder">
+            <img id="profile-avatar-image" class="profile-avatar-image" alt="Profile photo">
+            <div id="profile-avatar-placeholder" class="profile-avatar-placeholder">
                 {{ session.get('user', 'U')[0].upper() }}
             </div>
         </div>
         <div>
             <h2 class="mb-1">{{ session.get('user', 'User') }}</h2>
             <p class="text-muted mb-0">Coffee enthusiast · Perth WA</p>
+            <label for="profile-avatar-upload" class="btn btn-outline-coffee btn-sm mt-2">
+                <i class="bi bi-camera-fill"></i> Change photo
+            </label>
+            <input type="file" id="profile-avatar-upload" class="visually-hidden" accept="image/*">
         </div>
     </div>
 
@@ -95,7 +100,66 @@
 
 {% block extra_js %}
 <script>
-const currentUser = "{{ session.get('user', 'User') }}";
+const currentUser = {{ session.get('user', 'User')|tojson }};
+const avatarStorageKey = `profileAvatar:${currentUser}`;
+
+function getSavedAvatar() {
+    return localStorage.getItem(avatarStorageKey) || '';
+}
+
+function avatarMarkup(username, avatar) {
+    if (avatar) {
+        return `<img class="post-avatar-image" src="${avatar}" alt="${username} profile photo">`;
+    }
+
+    return `<div class="post-avatar-placeholder">${(username || 'U').charAt(0).toUpperCase()}</div>`;
+}
+
+function renderProfileAvatar() {
+    const avatar = getSavedAvatar();
+    const image = document.getElementById('profile-avatar-image');
+    const placeholder = document.getElementById('profile-avatar-placeholder');
+
+    if (avatar) {
+        image.src = avatar;
+        image.style.display = 'block';
+        placeholder.style.display = 'none';
+    } else {
+        image.removeAttribute('src');
+        image.style.display = 'none';
+        placeholder.style.display = 'flex';
+    }
+}
+
+function handleAvatarUpload(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = e => {
+        localStorage.setItem(avatarStorageKey, e.target.result);
+        syncUserPostAvatars(e.target.result);
+        if (window.updateNavbarAvatar) {
+            window.updateNavbarAvatar(e.target.result);
+        }
+        renderProfileAvatar();
+        loadProfilePosts();
+        event.target.value = '';
+    };
+    reader.readAsDataURL(file);
+}
+
+function syncUserPostAvatars(avatar) {
+    const posts = JSON.parse(localStorage.getItem('posts')) || [];
+    const updatedPosts = posts.map(post => {
+        if (post.username === currentUser) {
+            return { ...post, avatar };
+        }
+        return post;
+    });
+
+    localStorage.setItem('posts', JSON.stringify(updatedPosts));
+}
 
 function submitProfilePost() {
     const text = document.getElementById('profile-post-text').value.trim();
@@ -109,7 +173,7 @@ function submitProfilePost() {
     function createPost(imageData) {
         const post = {
             username: currentUser,
-            avatar: '',
+            avatar: getSavedAvatar(),
             text: text,
             shop: shop,
             image: imageData || '',
@@ -149,7 +213,13 @@ function loadProfilePosts() {
 
     feed.innerHTML = myPosts.map((p, i) => `
         <div class="card mb-3 p-3">
-            <p class="mb-1"><strong>${p.shop || ''}</strong></p>
+            <div class="profile-post-header">
+                ${avatarMarkup(p.username || currentUser, getSavedAvatar() || p.avatar)}
+                <div>
+                    <strong>${p.username || currentUser}</strong>
+                    <p class="small text-muted mb-0">${p.shop || ''}</p>
+                </div>
+            </div>
             ${p.image ? `<img src="${p.image}" class="img-fluid rounded mb-2" style="max-height:300px;object-fit:cover;">` : ''}
             <p class="mb-2">${p.text}</p>
 
@@ -195,6 +265,11 @@ function deleteProfileComment(postTime, index) {
     loadProfilePosts();
 }
 
-window.onload = loadProfilePosts;
+document.getElementById('profile-avatar-upload').addEventListener('change', handleAvatarUpload);
+
+window.onload = function() {
+    renderProfileAvatar();
+    loadProfilePosts();
+};
 </script>
 {% endblock %}

--- a/templates/social.html
+++ b/templates/social.html
@@ -109,6 +109,7 @@
 
 {% block extra_js %}
 <script>
+    const currentUser = {{ session.get('user', 'User')|tojson }};
     const routes = {
         blacklist: "{{ url_for('shop_blacklist') }}",
         laveen: "{{ url_for('shop_laveen') }}",


### PR DESCRIPTION
- Add profile photo upload on the profile page
- Store uploaded avatars in localStorage per user
- Show uploaded avatar on the profile page and navbar
- Use the saved avatar for posts in the social feed
- Fall back to letter/avatar placeholders when no photo is uploaded
- Update navbar avatar immediately after selecting a new photo