### PR TITLE
Feat add delete button for profile picture and updated the cafe dropdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,99 @@ users = {
     "admin": "1234"
 }
 
+CAFES = [
+    {
+        "name": "Blacklist Coffee Roasters",
+        "location": "Welshpool",
+        "rating": "4.8",
+        "hours": "7:00 AM - 3:00 PM",
+        "open": True,
+        "pet": False,
+        "cold_brew": True,
+        "pour_over": False,
+        "tags": ["Cold Brew"],
+        "route": "shop_blacklist"
+    },
+    {
+        "name": "La Veen Coffee",
+        "location": "Perth CBD",
+        "rating": "4.6",
+        "hours": "6:30 AM - 2:30 PM",
+        "open": True,
+        "pet": False,
+        "cold_brew": False,
+        "pour_over": True,
+        "tags": ["Pour Over"],
+        "route": "shop_laveen"
+    },
+    {
+        "name": "Venn Coffee",
+        "location": "Subiaco",
+        "rating": "4.7",
+        "hours": "7:00 AM - 4:00 PM",
+        "open": True,
+        "pet": True,
+        "cold_brew": False,
+        "pour_over": False,
+        "tags": ["Pet Friendly"],
+        "route": "shop_venn"
+    },
+    {
+        "name": "Harvest Espresso",
+        "location": "Leederville",
+        "rating": "4.7",
+        "hours": "6:30 AM - 2:00 PM",
+        "open": True,
+        "pet": False,
+        "cold_brew": True,
+        "pour_over": True,
+        "tags": ["Cold Brew", "Pour Over"],
+        "route": None
+    },
+    {
+        "name": "Telegram Cafe",
+        "location": "Northbridge",
+        "rating": "4.5",
+        "hours": "7:00 AM - 2:30 PM",
+        "open": True,
+        "pet": False,
+        "cold_brew": False,
+        "pour_over": True,
+        "tags": ["Pour Over"],
+        "route": None
+    },
+    {
+        "name": "Satchmo",
+        "location": "Mount Lawley",
+        "rating": "4.6",
+        "hours": "7:00 AM - 3:00 PM",
+        "open": True,
+        "pet": True,
+        "cold_brew": False,
+        "pour_over": False,
+        "tags": ["Pet Friendly"],
+        "route": None
+    },
+    {
+        "name": "Mary Street Bakery",
+        "location": "Perth CBD",
+        "rating": "4.4",
+        "hours": "7:00 AM - 3:00 PM",
+        "open": True,
+        "pet": False,
+        "cold_brew": True,
+        "pour_over": False,
+        "tags": ["Cold Brew"],
+        "route": None
+    }
+]
+
+
+@app.context_processor
+def inject_cafes():
+    trending_cafes = sorted(CAFES, key=lambda cafe: float(cafe["rating"]), reverse=True)[:3]
+    return {"cafes": CAFES, "trending_cafes": trending_cafes}
+
 # ── Auth Routes ──────────────────────────────────────────
 @app.route("/")
 def index():

--- a/static/js/social.js
+++ b/static/js/social.js
@@ -13,7 +13,7 @@ const defaultPosts = [
         username: "BrewMaster",
         avatar: "https://i.pravatar.cc/40?img=2",
         text: "Morning espresso hit 🔥",
-        shop: "Single Origin Roasters",
+        shop: "Blacklist Coffee Roasters",
         image: "https://images.unsplash.com/photo-1511920170033-f8396924c348",
         likes: 8,
         comments: [],
@@ -313,13 +313,6 @@ function submitModalPost() {
 
     reader.readAsDataURL(imageInput.files[0]);
 }
-
-function goToShop(id) {
-    if (id == 1) window.location.href = routes.blacklist;
-    if (id == 2) window.location.href = routes.laveen;
-    if (id == 3) window.location.href = routes.venn;
-}
-
 // ── LOGOUT ─────────────────────────
 function logout() {
     localStorage.clear();

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,8 +66,12 @@
             const avatarSlot = document.querySelector('[data-navbar-avatar]');
 
             function updateNavbarAvatar(avatarData) {
-                if (avatarData && avatarSlot) {
+                if (!avatarSlot) return;
+
+                if (avatarData) {
                     avatarSlot.innerHTML = `<img src="${avatarData}" alt="${currentUser} profile photo">`;
+                } else {
+                    avatarSlot.innerHTML = '<i class="bi bi-person-circle"></i>';
                 }
             }
 

--- a/templates/brew.html
+++ b/templates/brew.html
@@ -35,49 +35,29 @@
 
     <!-- SHOPS -->
     <div class="row g-4" id="shop-grid">
-
-        <div class="col-md-4 shop-item" data-open="true" data-pet="false" data-cold-brew="true" data-pour-over="false">
+        {% for cafe in cafes %}
+        <div class="col-md-4 shop-item" data-open="{{ cafe.open|lower }}" data-pet="{{ cafe.pet|lower }}" data-cold-brew="{{ cafe.cold_brew|lower }}" data-pour-over="{{ cafe.pour_over|lower }}">
             <div class="feature-card shop-card h-100">
                 <div class="d-flex justify-content-between align-items-start mb-2">
-                    <h5 class="mb-0">Blacklist Coffee Roasters</h5>
+                    <h5 class="mb-0">{{ cafe.name }}</h5>
                     <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
                 </div>
-                <p><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> Welshpool</p>
-                <p><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.8</p>
-                <p><i class="bi bi-clock" style="color:var(--caramel)"></i> 7:00 AM – 3:00 PM</p>
-                <div class="mt-2"><span class="shop-tag">Cold Brew</span></div>
-                <a href="{{ url_for('shop_blacklist') }}" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
-            </div>
-        </div>
-
-        <div class="col-md-4 shop-item" data-open="true" data-pet="false" data-cold-brew="false" data-pour-over="true">
-            <div class="feature-card shop-card h-100">
-                <div class="d-flex justify-content-between align-items-start mb-2">
-                    <h5 class="mb-0">La Veen Coffee</h5>
-                    <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
+                <p><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> {{ cafe.location }}</p>
+                <p><i class="bi bi-star-fill" style="color:var(--caramel)"></i> {{ cafe.rating }}</p>
+                <p><i class="bi bi-clock" style="color:var(--caramel)"></i> {{ cafe.hours }}</p>
+                <div class="mt-2">
+                    {% for tag in cafe.tags %}
+                    <span class="shop-tag">{{ tag }}</span>
+                    {% endfor %}
                 </div>
-                <p><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> Perth CBD</p>
-                <p><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.6</p>
-                <p><i class="bi bi-clock" style="color:var(--caramel)"></i> 6:30 AM – 2:30 PM</p>
-                <div class="mt-2"><span class="shop-tag">Pour Over</span></div>
-                <a href="{{ url_for('shop_laveen') }}" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
+                {% if cafe.route %}
+                <a href="{{ url_for(cafe.route) }}" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
+                {% else %}
+                <span class="btn btn-outline-nav mt-3 d-block text-center disabled">Details coming soon</span>
+                {% endif %}
             </div>
         </div>
-
-        <div class="col-md-4 shop-item" data-open="true" data-pet="true" data-cold-brew="false" data-pour-over="false">
-            <div class="feature-card shop-card h-100">
-                <div class="d-flex justify-content-between align-items-start mb-2">
-                    <h5 class="mb-0">Venn Coffee</h5>
-                    <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
-                </div>
-                <p><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> Subiaco</p>
-                <p><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.7</p>
-                <p><i class="bi bi-clock" style="color:var(--caramel)"></i> 7:00 AM – 4:00 PM</p>
-                <div class="mt-2"><span class="shop-tag">Pet Friendly</span></div>
-                <a href="{{ url_for('shop_venn') }}" class="btn btn-outline-nav mt-3 d-block text-center">View Details</a>
-            </div>
-        </div>
-
+        {% endfor %}
     </div>
 </main>
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -36,9 +36,9 @@
                 <textarea id="modal-text" placeholder="Share your coffee moment..."></textarea>
                 <label><i class="bi bi-geo-alt-fill"></i> Cafe</label>
                 <select id="modal-shop">
-                    <option>Blacklist Coffee Roasters</option>
-                    <option>La Veen Coffee</option>
-                    <option>Venn Coffee</option>
+                    {% for cafe in cafes %}
+                    <option>{{ cafe.name }}</option>
+                    {% endfor %}
                 </select>
                 <input type="file" id="modal-image" accept="image/*">
                 <div class="preview-container">
@@ -74,44 +74,28 @@
 
         <!-- Shop cards -->
         <div class="brew-grid" id="shop-grid">
-    <div class="shop-item" data-open="true" data-pet="false" data-cold-brew="true" data-pour-over="false">
+    {% for cafe in cafes %}
+    <div class="shop-item" data-open="{{ cafe.open|lower }}" data-pet="{{ cafe.pet|lower }}" data-cold-brew="{{ cafe.cold_brew|lower }}" data-pour-over="{{ cafe.pour_over|lower }}">
         <div class="feature-card shop-card h-100">
             <div class="d-flex justify-content-between align-items-start mb-2">
-                <h6 class="mb-0">Blacklist Coffee Roasters</h6>
+                <h6 class="mb-0">{{ cafe.name }}</h6>
                 <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
             </div>
-            <p class="mb-1"><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> Welshpool</p>
-            <p class="mb-1"><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.8</p>
-            <div class="mt-1 mb-2"><span class="shop-tag">Cold Brew</span></div>
-            <a href="{{ url_for('shop_blacklist') }}" class="btn btn-outline-nav mt-auto d-block text-center">View Details</a>
-        </div>
-    </div>
-
-    <div class="shop-item" data-open="true" data-pet="false" data-cold-brew="false" data-pour-over="true">
-        <div class="feature-card shop-card h-100">
-            <div class="d-flex justify-content-between align-items-start mb-2">
-                <h6 class="mb-0">La Veen Coffee</h6>
-                <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
+            <p class="mb-1"><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> {{ cafe.location }}</p>
+            <p class="mb-1"><i class="bi bi-star-fill" style="color:var(--caramel)"></i> {{ cafe.rating }}</p>
+            <div class="mt-1 mb-2">
+                {% for tag in cafe.tags %}
+                <span class="shop-tag">{{ tag }}</span>
+                {% endfor %}
             </div>
-            <p class="mb-1"><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> Perth CBD</p>
-            <p class="mb-1"><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.6</p>
-            <div class="mt-1 mb-2"><span class="shop-tag">Pour Over</span></div>
-            <a href="{{ url_for('shop_laveen') }}" class="btn btn-outline-nav mt-auto d-block text-center">View Details</a>
+            {% if cafe.route %}
+            <a href="{{ url_for(cafe.route) }}" class="btn btn-outline-nav mt-auto d-block text-center">View Details</a>
+            {% else %}
+            <span class="btn btn-outline-nav mt-auto d-block text-center disabled">Details coming soon</span>
+            {% endif %}
         </div>
     </div>
-
-    <div class="shop-item" data-open="true" data-pet="true" data-cold-brew="false" data-pour-over="false">
-        <div class="feature-card shop-card h-100">
-            <div class="d-flex justify-content-between align-items-start mb-2">
-                <h6 class="mb-0">Venn Coffee</h6>
-                <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
-            </div>
-            <p class="mb-1"><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> Subiaco</p>
-            <p class="mb-1"><i class="bi bi-star-fill" style="color:var(--caramel)"></i> 4.7</p>
-            <div class="mt-1 mb-2"><span class="shop-tag">Pet Friendly</span></div>
-            <a href="{{ url_for('shop_venn') }}" class="btn btn-outline-nav mt-auto d-block text-center">View Details</a>
-        </div>
-    </div>
+    {% endfor %}
 </div>
     </div>
 
@@ -122,9 +106,6 @@
 <script>
     const currentUser = {{ session.get('user', 'User')|tojson }};
     const routes = {
-        blacklist: "{{ url_for('shop_blacklist') }}",
-        laveen: "{{ url_for('shop_laveen') }}",
-        venn: "{{ url_for('shop_venn') }}",
         landing: "{{ url_for('landing') }}"
     };
 </script>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -48,9 +48,9 @@
                     placeholder="What are you brewing today?" rows="3"></textarea>
                 <select id="profile-post-shop" class="form-select mb-2">
                     <option value="">Tag a cafe...</option>
-                    <option>Blacklist Coffee Roasters</option>
-                    <option>La Veen Coffee</option>
-                    <option>Venn Coffee</option>
+                    {% for cafe in cafes %}
+                    <option>{{ cafe.name }}</option>
+                    {% endfor %}
                 </select>
                 <input type="file" id="profile-post-image" class="form-control mb-2" accept="image/*">
                 <button class="btn btn-primary-custom w-100" onclick="submitProfilePost()">Post</button>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -29,6 +29,9 @@
             <label for="profile-avatar-upload" class="btn btn-outline-coffee btn-sm mt-2">
                 <i class="bi bi-camera-fill"></i> Change photo
             </label>
+            <button type="button" id="profile-avatar-remove" class="btn btn-outline-danger btn-sm mt-2 ms-2">
+                <i class="bi bi-trash"></i> Remove photo
+            </button>
             <input type="file" id="profile-avatar-upload" class="visually-hidden" accept="image/*">
         </div>
     </div>
@@ -119,15 +122,18 @@ function renderProfileAvatar() {
     const avatar = getSavedAvatar();
     const image = document.getElementById('profile-avatar-image');
     const placeholder = document.getElementById('profile-avatar-placeholder');
+    const removeButton = document.getElementById('profile-avatar-remove');
 
     if (avatar) {
         image.src = avatar;
         image.style.display = 'block';
         placeholder.style.display = 'none';
+        removeButton.style.display = 'inline-block';
     } else {
         image.removeAttribute('src');
         image.style.display = 'none';
         placeholder.style.display = 'flex';
+        removeButton.style.display = 'none';
     }
 }
 
@@ -147,6 +153,20 @@ function handleAvatarUpload(event) {
         event.target.value = '';
     };
     reader.readAsDataURL(file);
+}
+
+function removeProfileAvatar() {
+    if (!getSavedAvatar()) return;
+
+    localStorage.removeItem(avatarStorageKey);
+    syncUserPostAvatars('');
+
+    if (window.updateNavbarAvatar) {
+        window.updateNavbarAvatar('');
+    }
+
+    renderProfileAvatar();
+    loadProfilePosts();
 }
 
 function syncUserPostAvatars(avatar) {
@@ -266,6 +286,7 @@ function deleteProfileComment(postTime, index) {
 }
 
 document.getElementById('profile-avatar-upload').addEventListener('change', handleAvatarUpload);
+document.getElementById('profile-avatar-remove').addEventListener('click', removeProfileAvatar);
 
 window.onload = function() {
     renderProfileAvatar();

--- a/templates/social.html
+++ b/templates/social.html
@@ -27,26 +27,22 @@
             <i class="bi bi-fire"></i> Trending Cafes
         </h5>
 
-        <div class="shop-item" onclick="goToShop(1)">
-            <strong>Single Origin Roasters</strong>
+        {% for cafe in trending_cafes %}
+        {% if cafe.route %}
+        <a class="shop-item text-decoration-none text-reset" href="{{ url_for(cafe.route) }}">
+        {% else %}
+        <div class="shop-item">
+        {% endif %}
+            <strong>{{ cafe.name }}</strong>
             <span>
-                <i class="bi bi-star-fill text-warning"></i> 4.8
+                <i class="bi bi-star-fill text-warning"></i> {{ cafe.rating }}
             </span>
+        {% if cafe.route %}
+        </a>
+        {% else %}
         </div>
-
-        <div class="shop-item" onclick="goToShop(2)">
-            <strong>La Veen Coffee</strong>
-            <span>
-                <i class="bi bi-star-fill text-warning"></i> 4.6
-            </span>
-        </div>
-
-        <div class="shop-item" onclick="goToShop(3)">
-            <strong>Venn Coffee</strong>
-            <span>
-                <i class="bi bi-star-fill text-warning"></i> 4.7
-            </span>
-        </div>
+        {% endif %}
+        {% endfor %}
     </div>
 
     <!-- FEED -->
@@ -78,9 +74,9 @@
             <i class="bi bi-geo-alt-fill"></i> Cafe
         </label>
         <select id="modal-shop">
-            <option>Single Origin Roasters</option>
-            <option>La Veen Coffee</option>
-            <option>Venn Coffee</option>
+            {% for cafe in cafes %}
+            <option>{{ cafe.name }}</option>
+            {% endfor %}
         </select>
 
         <label>
@@ -111,9 +107,6 @@
 <script>
     const currentUser = {{ session.get('user', 'User')|tojson }};
     const routes = {
-        blacklist: "{{ url_for('shop_blacklist') }}",
-        laveen: "{{ url_for('shop_laveen') }}",
-        venn: "{{ url_for('shop_venn') }}",
         landing: "{{ url_for('landing') }}"
     };
 </script>


### PR DESCRIPTION
Centralized cafe data in app.py

Added a shared CAFES list in app.py so cafe names, locations, ratings, hours, tags, filters, and detail routes are stored in one place instead of being hardcoded separately across templates.


Added new cafes

Added Harvest Espresso, Telegram Cafe, Satchmo, and Mary Street Bakery to the shared cafe list so they appear across the app wherever cafe data is rendered.


Updated Brew Map page

Changed templates/brew.html so the Brew Map cards are generated from the shared CAFES list. This keeps the Brew Map in sync whenever cafes are added or changed.


Updated Home page Brew Map

Changed templates/home.html so the Brew map section on the home page also uses the shared CAFES list instead of its own separate hardcoded cafe cards.


Updated post modal dropdowns

Changed the cafe dropdown in the Home page post modal, Social Grounds post modal, and Profile post form so all of them use the same shared CAFES list.


Updated Social Grounds trending sidebar

Changed templates/social.html so the Trending Cafes sidebar is generated from the highest-rated cafes in the shared cafe list.


Removed stale cafe reference

Updated static/js/social.js to replace the old Single Origin Roasters seeded post reference with Blacklist Coffee Roasters, keeping seed data aligned with the current cafe list.


Removed unused hardcoded routing helper

Removed the old goToShop helper from static/js/social.js because the trending sidebar now uses direct template-rendered links.
