### PR TITLE
fix: JS cleanup, shop pages, social feed and profile fixes (closes #36, #37)

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ CAFES = [
         "cold_brew": True,
         "pour_over": True,
         "tags": ["Cold Brew", "Pour Over"],
-        "route": None
+        "route": "shop_harvest"
     },
     {
         "name": "Telegram Cafe",
@@ -68,7 +68,7 @@ CAFES = [
         "cold_brew": False,
         "pour_over": True,
         "tags": ["Pour Over"],
-        "route": None
+        "route": "shop_telegram"
     },
     {
         "name": "Satchmo",
@@ -80,7 +80,7 @@ CAFES = [
         "cold_brew": False,
         "pour_over": False,
         "tags": ["Pet Friendly"],
-        "route": None
+        "route": "shop_satchmo"
     },
     {
         "name": "Mary Street Bakery",
@@ -92,7 +92,7 @@ CAFES = [
         "cold_brew": True,
         "pour_over": False,
         "tags": ["Cold Brew"],
-        "route": None
+        "route": "shop_marystreet"
     }
 ]
 
@@ -183,6 +183,22 @@ def shop_laveen():
 @app.route("/shop/venn")
 def shop_venn():
     return render_template("shop-venn.html")
+
+@app.route("/shop/harvest")
+def shop_harvest():
+    return render_template("shop-harvest.html")
+
+@app.route("/shop/telegram")
+def shop_telegram():
+    return render_template("shop-telegram.html")
+
+@app.route("/shop/satchmo")
+def shop_satchmo():
+    return render_template("shop-satchmo.html")
+
+@app.route("/shop/marystreet")
+def shop_marystreet():
+    return render_template("shop-marystreet.html")
 
 @app.route("/home")
 def home():

--- a/static/js/delete.js
+++ b/static/js/delete.js
@@ -1,0 +1,45 @@
+// ── DELETE POST ─────────────────────────
+function deletePost(postTime) {
+    if (!confirm('Are you sure you want to delete this post?')) return;
+    let posts = JSON.parse(localStorage.getItem('posts')) || [];
+    posts = posts.filter(p => p.time !== postTime);
+    localStorage.setItem('posts', JSON.stringify(posts));
+
+    if (document.getElementById("profile-feed")) loadProfilePosts();
+    else loadPosts();
+}
+
+// ── DELETE COMMENT ─────────────────────────
+function deleteComment(postTime, index) {
+    if (!confirm('Are you sure you want to delete this comment?')) return;
+    let posts = JSON.parse(localStorage.getItem('posts')) || [];
+    posts = posts.map(p => {
+        if (p.time === postTime) p.comments.splice(index, 1);
+        return p;
+    });
+    localStorage.setItem('posts', JSON.stringify(posts));
+
+    if (document.getElementById("profile-feed")) loadProfilePosts();
+    else loadPosts();
+}
+
+// ── DELETE PROFILE POST ─────────────────────────
+function deleteProfilePost(postTime) {
+    if (!confirm('Are you sure you want to delete this post?')) return;
+    let posts = JSON.parse(localStorage.getItem('posts')) || [];
+    posts = posts.filter(p => p.time !== postTime);
+    localStorage.setItem('posts', JSON.stringify(posts));
+    loadProfilePosts();
+}
+
+// ── DELETE PROFILE COMMENT ─────────────────────────
+function deleteProfileComment(postTime, index) {
+    if (!confirm('Are you sure you want to delete this comment?')) return;
+    let posts = JSON.parse(localStorage.getItem('posts')) || [];
+    posts = posts.map(p => {
+        if (p.time === postTime) p.comments.splice(index, 1);
+        return p;
+    });
+    localStorage.setItem('posts', JSON.stringify(posts));
+    loadProfilePosts();
+}

--- a/static/js/navbar.js
+++ b/static/js/navbar.js
@@ -1,0 +1,20 @@
+// ── NAVBAR AVATAR ─────────────────────────
+(function () {
+    const currentUser = window.currentUser || "";
+    if (!currentUser) return;
+
+    const avatar = localStorage.getItem(`profileAvatar:${currentUser}`);
+    const avatarSlot = document.querySelector('[data-navbar-avatar]');
+
+    function updateNavbarAvatar(avatarData) {
+        if (!avatarSlot) return;
+        if (avatarData) {
+            avatarSlot.innerHTML = `<img src="${avatarData}" alt="${currentUser} profile photo">`;
+        } else {
+            avatarSlot.innerHTML = '<i class="bi bi-person-circle"></i>';
+        }
+    }
+
+    updateNavbarAvatar(avatar);
+    window.updateNavbarAvatar = updateNavbarAvatar;
+})();

--- a/static/js/profile.js
+++ b/static/js/profile.js
@@ -1,0 +1,186 @@
+// ── PROFILE PAGE ─────────────────────────
+const avatarStorageKey = `profileAvatar:${window.currentUser}`;
+
+function getSavedAvatar() {
+    return localStorage.getItem(avatarStorageKey) || '';
+}
+
+function renderProfileAvatar() {
+    const avatar = getSavedAvatar();
+    const image = document.getElementById('profile-avatar-image');
+    const placeholder = document.getElementById('profile-avatar-placeholder');
+    const removeButton = document.getElementById('profile-avatar-remove');
+
+    if (avatar) {
+        image.src = avatar;
+        image.style.display = 'block';
+        placeholder.style.display = 'none';
+        removeButton.style.display = 'inline-block';
+    } else {
+        image.removeAttribute('src');
+        image.style.display = 'none';
+        placeholder.style.display = 'flex';
+        removeButton.style.display = 'none';
+    }
+}
+
+function handleAvatarUpload(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+        localStorage.setItem(avatarStorageKey, e.target.result);
+        syncUserPostAvatars(e.target.result);
+        renderProfileAvatar();
+        loadProfilePosts();
+        event.target.value = '';
+    };
+    reader.readAsDataURL(file);
+}
+
+function removeProfileAvatar() {
+    if (!confirm('Are you sure you want to remove your profile picture?')) return;
+    if (!getSavedAvatar()) return;
+    localStorage.removeItem(avatarStorageKey);
+    syncUserPostAvatars('');
+    renderProfileAvatar();
+    loadProfilePosts();
+}
+
+function syncUserPostAvatars(avatar) {
+    const posts = JSON.parse(localStorage.getItem('posts')) || [];
+    const updated = posts.map(post => {
+        if (post.username === window.currentUser) return { ...post, avatar };
+        return post;
+    });
+    localStorage.setItem('posts', JSON.stringify(updated));
+}
+
+function previewProfileImage(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = function (e) {
+        const img = document.getElementById("profile-image-preview");
+        const ratio = document.getElementById("aspect-ratio").value;
+        img.src = e.target.result;
+        img.style.display = "block";
+        if (ratio === "square")         img.style.aspectRatio = "1 / 1";
+        else if (ratio === "portrait")  img.style.aspectRatio = "4 / 5";
+        else if (ratio === "landscape") img.style.aspectRatio = "16 / 9";
+        else                            img.style.aspectRatio = "auto";
+    };
+    reader.readAsDataURL(file);
+}
+
+function submitProfilePost() {
+    const text = document.getElementById('profile-post-text').value.trim();
+    const shop = document.getElementById('profile-post-shop').value;
+    const imageInput = document.getElementById('profile-post-image');
+
+    if (!text) { alert('Please write something!'); return; }
+
+    function createPost(imageData) {
+        const postData = {
+            username: window.currentUser,
+            owner: window.currentUser,
+            avatar: getSavedAvatar(),
+            text,
+            shop,
+            image: imageData || '',
+            likes: 0,
+            likedBy: [],
+            comments: [],
+            time: new Date().toISOString()
+        };
+        savePost(postData);
+        loadProfilePosts();
+        document.getElementById('profile-post-text').value = '';
+        document.getElementById('profile-post-shop').value = '';
+        document.getElementById('profile-post-image').value = '';
+        document.getElementById('profile-image-preview').style.display = "none";
+    }
+
+    if (imageInput.files.length > 0) {
+        const reader = new FileReader();
+        reader.onload = e => createPost(e.target.result);
+        reader.readAsDataURL(imageInput.files[0]);
+    } else {
+        createPost('');
+    }
+}
+
+function loadProfilePosts() {
+    let posts = JSON.parse(localStorage.getItem("posts")) || [];
+    const myPosts = posts.filter(p => p.owner === window.currentUser || p.username === window.currentUser);
+    const feed = document.getElementById("profile-feed");
+    feed.innerHTML = "";
+
+    if (myPosts.length === 0) {
+        feed.innerHTML = "<p class='text-muted'>No posts yet. Share your first coffee moment!</p>";
+        return;
+    }
+
+    myPosts.forEach(p => {
+        const div = document.createElement('div');
+        div.className = 'card mb-3 p-3';
+        div.innerHTML = `
+            <div class="d-flex align-items-center gap-2 mb-2">
+                ${getSavedAvatar()
+                    ? `<img src="${getSavedAvatar()}" class="avatar">`
+                    : `<div class="avatar avatar-placeholder">${window.currentUser[0].toUpperCase()}</div>`}
+                <div>
+                    <strong>${p.username || window.currentUser}</strong>
+                    <p class="small text-muted mb-0">${p.shop || ''}</p>
+                </div>
+            </div>
+            ${p.image ? `<img src="${p.image}" class="img-fluid rounded mb-2" style="max-height:300px;object-fit:cover;">` : ''}
+            <p class="mb-2">${p.text}</p>
+            <button class="btn btn-sm btn-outline-danger" onclick="deleteProfilePost('${p.time}')">
+                <i class="bi bi-trash"></i> Delete Post
+            </button>
+            <div class="mt-2">
+                ${(p.comments || []).map((c, ci) => `
+                    <div class="d-flex justify-content-between align-items-start mb-1">
+                        <p class="small mb-0"><strong>${c.username}</strong> ${c.text}</p>
+                        <button class="btn btn-sm p-0 ms-2" style="color:var(--caramel);font-size:0.75rem;"
+                            onclick="deleteProfileComment('${p.time}', ${ci})">Delete</button>
+                    </div>
+                `).join('')}
+                <input type="text" class="form-control form-control-sm mt-2"
+                    placeholder="Add a comment..."
+                    onkeypress="addProfileComment(event, '${p.time}', this)">
+            </div>
+        `;
+        feed.appendChild(div);
+    });
+}
+
+function addProfileComment(e, postTime, input) {
+    if (e.key === 'Enter' && input.value.trim()) {
+        let posts = JSON.parse(localStorage.getItem('posts')) || [];
+        posts = posts.map(p => {
+            if (p.time === postTime) {
+                if (!p.comments) p.comments = [];
+                p.comments.push({
+                    username: window.currentUser,
+                    owner: window.currentUser,
+                    text: input.value.trim(),
+                    time: new Date().toISOString()
+                });
+            }
+            return p;
+        });
+        localStorage.setItem('posts', JSON.stringify(posts));
+        loadProfilePosts();
+    }
+}
+
+// ── INIT ─────────────────────────
+document.getElementById('profile-avatar-upload').addEventListener('change', handleAvatarUpload);
+document.getElementById('profile-avatar-remove').addEventListener('click', removeProfileAvatar);
+
+window.onload = function () {
+    renderProfileAvatar();
+    loadProfilePosts();
+};

--- a/static/js/social.js
+++ b/static/js/social.js
@@ -196,26 +196,15 @@ function renderPost(postData, prepend = false) {
     </div>
 
     <div class="post-caption">
-        <strong>${postData.username || "Anonymous"}</strong> ${postData.text || ""}
-    </div>
+    <strong>${username}</strong> ${postData.text || ""}
+</div>
 
 <div class="comment-list">
 ${(postData.comments || [])
     .filter(c => typeof c === "object")
     .map((c, index) => {
-
-        const canDelete =
-            c.owner === currentUser || postData.owner === currentUser;
-
-        const canEdit =
-            c.owner === currentUser;
-    <div class="post-caption d-flex justify-content-between align-items-start">
-    <span><strong>${username}</strong> ${postData.text || ""}</span>
-    <button onclick="deletePost('${postData.time}')" 
-        style="border:none;background:none;color:var(--muted);font-size:0.8rem;cursor:pointer;">
-        <i class="bi bi-trash"></i>
-    </button>
-</div>
+        const canDelete = c.owner === currentUser || postData.owner === currentUser;
+        const canEdit = c.owner === currentUser;
 
         return `
         <div class="comment">
@@ -306,12 +295,11 @@ function addComment(e, postTime, input) {
                 if (!p.comments) p.comments = [];
 
                 p.comments.push({
-                    username: user.name,
-                    owner: currentUser,   // ✅ IMPORTANT
-                    username: activeUser,
-                    text: commentText,
-                    time: new Date().toISOString()
-                });
+    username: currentUser,
+    owner: currentUser,
+    text: commentText,
+    time: new Date().toISOString()
+});
             }
             return p;
         });
@@ -325,24 +313,6 @@ function addComment(e, postTime, input) {
     }
 }
 
-// ── DELETE COMMENT ─────────────────────────
-function deleteComment(postTime, index) {
-    let posts = JSON.parse(localStorage.getItem("posts")) || [];
-
-    posts = posts.map(p => {
-        if (p.time === postTime) {
-            p.comments.splice(index, 1);
-        }
-        return p;
-    });
-
-    updateStorage(posts);
-    if (document.getElementById("profile-feed")) {
-        loadProfilePosts();
-    } else {
-        loadPosts();
-    }
-}
 
 // ── EDIT COMMENT ─────────────────────────
 function editComment(postTime, index, el) {
@@ -406,7 +376,27 @@ function resetModal() {
     const container = document.querySelector(".preview-container");
     container.style.display = "none";
 }
+// ── IMAGE PREVIEW (modal) ─────────────────────────
+function previewImage(event) {
+    const file = event.target.files[0];
+    if (!file) return;
 
+    const reader = new FileReader();
+    reader.onload = function (e) {
+        const preview = document.getElementById("image-preview");
+        const container = document.querySelector(".preview-container");
+        const ratio = document.getElementById("aspect-ratio")?.value || "original";
+
+        preview.src = e.target.result;
+        container.style.display = "block";
+
+        if (ratio === "square")    preview.style.aspectRatio = "1 / 1";
+        else if (ratio === "portrait")  preview.style.aspectRatio = "4 / 5";
+        else if (ratio === "landscape") preview.style.aspectRatio = "16 / 9";
+        else preview.style.aspectRatio = "auto";
+    };
+    reader.readAsDataURL(file);
+}
 // ── CREATE POST ─────────────────────────
 function submitModalPost() {
     const text = document.getElementById("modal-text").value.trim();
@@ -445,16 +435,6 @@ function submitModalPost() {
             else if (aspect === "landscape") {
                 height = width * (9 / 16);
             }
-        const postData = {
-            username: activeUser,
-            avatar: getSavedAvatar(),
-            text,
-            shop,
-            image: e.target.result,
-            likes: 0,
-            comments: [],
-            time: new Date().toISOString()
-        };
 
             canvas.width = width;
             canvas.height = height;
@@ -499,32 +479,4 @@ function submitModalPost() {
 function logout() {
     localStorage.clear();
     window.location.href = routes.landing;
-}
-// ── DELETE POST ─────────────────────────
-function deletePost(postTime) {
-    if (!confirm('Delete this post?')) return;
-    
-    let posts = JSON.parse(localStorage.getItem('posts')) || [];
-    posts = posts.filter(p => p.time !== postTime);
-    localStorage.setItem('posts', JSON.stringify(posts));
-    if (document.getElementById("profile-feed")) {
-        loadProfilePosts();
-    } else {
-        loadPosts();
-    }
-}
-document.addEventListener("DOMContentLoaded", function () {
-    const aspectDropdown = document.getElementById("aspect-ratio");
-
-    if (aspectDropdown) {
-        aspectDropdown.addEventListener("change", function () {
-            const fileInput = document.getElementById("modal-image");
-
-            if (fileInput.files.length > 0) {
-                previewImage({ target: fileInput });
-            }
-        });
-    }
-});
-    loadPosts();
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,30 +17,30 @@
     <nav class="navbar navbar-expand-lg">
         <div class="container">
             {% if not session.get('user') %}
-<a class="navbar-brand" href="{{ url_for('landing') }}">Coffee Social Hub</a>
-{% endif %}
+            <a class="navbar-brand" href="{{ url_for('landing') }}">Coffee Social Hub</a>
+            {% endif %}
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navMenu">
                 <ul class="navbar-nav ms-auto align-items-center gap-2">
                     {% if session.get("user") %}
-    <li class="nav-item">
-        <a class="nav-link nav-profile-link" href="{{ url_for('profile') }}">
-            <span class="nav-profile-avatar" data-navbar-avatar>
-                <i class="bi bi-person-circle"></i>
-            </span>
-            <span>{{ session.get('user') }}</span>
-        </a>
-    </li>
-    <li class="nav-item">
-        <a class="btn btn-nav" href="{{ url_for('logout') }}">Logout</a>
-    </li>
-{% else %}
-    <li class="nav-item">
-        <a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a>
-    </li>
-{% endif %}
+                    <li class="nav-item">
+                        <a class="nav-link nav-profile-link" href="{{ url_for('profile') }}">
+                            <span class="nav-profile-avatar" data-navbar-avatar>
+                                <i class="bi bi-person-circle"></i>
+                            </span>
+                            <span>{{ session.get('user') }}</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="btn btn-nav" href="{{ url_for('logout') }}">Logout</a>
+                    </li>
+                    {% else %}
+                    <li class="nav-item">
+                        <a class="btn btn-nav" href="{{ url_for('login') }}">Login / Sign Up</a>
+                    </li>
+                    {% endif %}
                 </ul>
             </div>
         </div>
@@ -58,28 +58,15 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+
     {% if session.get("user") %}
     <script>
-        (function() {
-            const currentUser = {{ session.get('user')|tojson }};
-            const avatar = localStorage.getItem(`profileAvatar:${currentUser}`);
-            const avatarSlot = document.querySelector('[data-navbar-avatar]');
-
-            function updateNavbarAvatar(avatarData) {
-                if (!avatarSlot) return;
-
-                if (avatarData) {
-                    avatarSlot.innerHTML = `<img src="${avatarData}" alt="${currentUser} profile photo">`;
-                } else {
-                    avatarSlot.innerHTML = '<i class="bi bi-person-circle"></i>';
-                }
-            }
-
-            updateNavbarAvatar(avatar);
-            window.updateNavbarAvatar = updateNavbarAvatar;
-        })();
+        window.currentUser = {{ session.get('user')|tojson }};
     </script>
+    <script src="{{ url_for('static', filename='js/navbar.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/delete.js') }}"></script>
     {% endif %}
+
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -40,10 +40,7 @@
                     <option>{{ cafe.name }}</option>
                     {% endfor %}
                 </select>
-                <label>
-                    <i class="bi bi-image-fill"></i> Image Style
-                </label>
-
+                <label><i class="bi bi-image-fill"></i> Image Style</label>
                 <select id="aspect-ratio">
                     <option value="original">Original</option>
                     <option value="square">Square (1:1)</option>
@@ -67,7 +64,6 @@
             <h5><i class="bi bi-map-fill"></i> Brew Map</h5>
         </div>
 
-        <!-- Filters -->
         <div class="filters">
             <button class="filter-chip active-filter" data-filter="all">All</button>
             <button class="filter-chip" data-filter="open">Open Now</button>
@@ -76,37 +72,35 @@
             <button class="filter-chip" data-filter="pour-over">Pour Over</button>
         </div>
 
-        <!-- No results -->
         <div id="no-results" style="display:none; text-align:center; padding:2rem 0; color:var(--muted);">
             <i class="bi bi-search"></i>
             <p class="mt-2">No cafes match this filter.</p>
         </div>
 
-        <!-- Shop cards -->
         <div class="brew-grid" id="shop-grid">
-    {% for cafe in cafes %}
-    <div class="shop-item" data-open="{{ cafe.open|lower }}" data-pet="{{ cafe.pet|lower }}" data-cold-brew="{{ cafe.cold_brew|lower }}" data-pour-over="{{ cafe.pour_over|lower }}">
-        <div class="feature-card shop-card h-100">
-            <div class="d-flex justify-content-between align-items-start mb-2">
-                <h6 class="mb-0">{{ cafe.name }}</h6>
-                <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
+            {% for cafe in cafes %}
+            <div class="shop-item" data-open="{{ cafe.open|lower }}" data-pet="{{ cafe.pet|lower }}" data-cold-brew="{{ cafe.cold_brew|lower }}" data-pour-over="{{ cafe.pour_over|lower }}">
+                <div class="feature-card shop-card h-100">
+                    <div class="d-flex justify-content-between align-items-start mb-2">
+                        <h6 class="mb-0">{{ cafe.name }}</h6>
+                        <span class="badge" style="background:rgba(76,175,80,0.15);color:#4caf50;font-size:0.72rem;">Open</span>
+                    </div>
+                    <p class="mb-1"><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> {{ cafe.location }}</p>
+                    <p class="mb-1"><i class="bi bi-star-fill" style="color:var(--caramel)"></i> {{ cafe.rating }}</p>
+                    <div class="mt-1 mb-2">
+                        {% for tag in cafe.tags %}
+                        <span class="shop-tag">{{ tag }}</span>
+                        {% endfor %}
+                    </div>
+                    {% if cafe.route %}
+                    <a href="{{ url_for(cafe.route) }}" class="btn btn-outline-nav mt-auto d-block text-center">View Details</a>
+                    {% else %}
+                    <span class="btn btn-outline-nav mt-auto d-block text-center disabled">Details coming soon</span>
+                    {% endif %}
+                </div>
             </div>
-            <p class="mb-1"><i class="bi bi-geo-alt" style="color:var(--caramel)"></i> {{ cafe.location }}</p>
-            <p class="mb-1"><i class="bi bi-star-fill" style="color:var(--caramel)"></i> {{ cafe.rating }}</p>
-            <div class="mt-1 mb-2">
-                {% for tag in cafe.tags %}
-                <span class="shop-tag">{{ tag }}</span>
-                {% endfor %}
-            </div>
-            {% if cafe.route %}
-            <a href="{{ url_for(cafe.route) }}" class="btn btn-outline-nav mt-auto d-block text-center">View Details</a>
-            {% else %}
-            <span class="btn btn-outline-nav mt-auto d-block text-center disabled">Details coming soon</span>
-            {% endif %}
+            {% endfor %}
         </div>
-    </div>
-    {% endfor %}
-</div>
     </div>
 
 </div>
@@ -114,13 +108,7 @@
 
 {% block extra_js %}
 <script>
-    const currentUser = {{ session.get('user', 'User')|tojson }};
-    const routes = {
-        landing: "{{ url_for('landing') }}"
-    };
-</script>
-<script>
-    window.currentUser = "{{ session.get('user') }}";
+    window.routes = { landing: "{{ url_for('landing') }}" };
 </script>
 <script src="{{ url_for('static', filename='js/social.js') }}"></script>
 <script src="{{ url_for('static', filename='js/brew.js') }}"></script>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -9,20 +9,15 @@
 {% block content %}
 <div class="container py-4">
 
-<div class="mb-3">
-    <a href="{{ url_for('home') }}" class="btn btn-outline-coffee btn-sm">
-        <i class="bi bi-arrow-left"></i> Back to Home
-    </a>
-</div>
+    <div class="mb-3">
+        <a href="{{ url_for('home') }}" class="btn btn-outline-coffee btn-sm">
+            <i class="bi bi-arrow-left"></i> Back to Home
+        </a>
+    </div>
 
-<div class="profile-header d-flex align-items-center gap-4 mb-4">
-    <div class="profile-avatar-wrapper">
-        <div class="profile-avatar-placeholder">
-            {{ session.get('user', 'U')[0].upper() }}
-    <!-- Profile Header -->
     <div class="profile-header d-flex align-items-center gap-4 mb-4">
         <div class="profile-avatar-wrapper">
-            <img id="profile-avatar-image" class="profile-avatar-image" alt="Profile photo">
+            <img id="profile-avatar-image" class="profile-avatar-image" style="display:none;" alt="Profile photo">
             <div id="profile-avatar-placeholder" class="profile-avatar-placeholder">
                 {{ session.get('user', 'U')[0].upper() }}
             </div>
@@ -33,24 +28,15 @@
             <label for="profile-avatar-upload" class="btn btn-outline-coffee btn-sm mt-2">
                 <i class="bi bi-camera-fill"></i> Change photo
             </label>
-            <button type="button" id="profile-avatar-remove" class="btn btn-outline-danger btn-sm mt-2 ms-2">
+            <button type="button" id="profile-avatar-remove" class="btn btn-outline-danger btn-sm mt-2 ms-2" style="display:none;">
                 <i class="bi bi-trash"></i> Remove photo
             </button>
             <input type="file" id="profile-avatar-upload" class="visually-hidden" accept="image/*">
         </div>
     </div>
-    <div>
-        <h2 class="mb-1">{{ session.get('user', 'User') }}</h2>
-        <p class="text-muted mb-0">Coffee enthusiast · Perth WA</p>
-    </div>
-</div>
 
     <div class="row g-4">
-
-        <!-- LEFT — Create Post + My Posts -->
         <div class="col-lg-8">
-
-            <!-- Create Post Box -->
             <div class="card mb-4 p-3">
                 <h6 class="mb-3">Share a coffee moment</h6>
                 <textarea id="profile-post-text" class="form-control mb-2"
@@ -61,307 +47,55 @@
                     <option>{{ cafe.name }}</option>
                     {% endfor %}
                 </select>
-                <input type="file" id="profile-post-image" class="form-control mb-2" accept="image/*">
-                <button class="btn btn-primary-custom w-100" onclick="submitProfilePost()">Post</button>
+                <select id="aspect-ratio" class="form-select mb-2">
+                    <option value="original">Original</option>
+                    <option value="square">Square (1:1)</option>
+                    <option value="portrait">Portrait (4:5)</option>
+                    <option value="landscape">Landscape (16:9)</option>
+                </select>
+                <input type="file" id="profile-post-image" class="form-control mb-2"
+                    accept="image/*" onchange="previewProfileImage(event)">
+                <img id="profile-image-preview"
+                    style="width:100%; display:none; border-radius:10px; margin-top:8px; object-fit:cover;">
+                <button class="btn btn-primary-custom w-100 mt-2" onclick="submitProfilePost()">Post</button>
             </div>
 
-<div class="col-lg-8">
-
-    <div class="card mb-4 p-3">
-        <h6 class="mb-3">Share a coffee moment</h6>
-
-        <textarea id="profile-post-text" class="form-control mb-2"
-            placeholder="What are you brewing today?" rows="3"></textarea>
-
-        <select id="profile-post-shop" class="form-select mb-2">
-            <option value="">Tag a cafe...</option>
-            <option>Blacklist Coffee Roasters</option>
-            <option>La Veen Coffee</option>
-            <option>Venn Coffee</option>
-        </select>
-
-        <select id="aspect-ratio" class="form-select mb-2">
-            <option value="original">Original</option>
-            <option value="square">Square (1:1)</option>
-            <option value="portrait">Portrait (4:5)</option>
-            <option value="landscape">Landscape (16:9)</option>
-        </select>
-
-        <input type="file" id="profile-post-image" class="form-control mb-2"
-            accept="image/*" onchange="previewProfileImage(event)">
-
-        <img id="profile-image-preview"
-            style="width:100%; display:none; border-radius:10px; margin-top:8px; object-fit:cover;">
-
-        <button class="btn btn-primary-custom w-100" onclick="submitProfilePost()">Post</button>
-    </div>
-
-    <h5 class="mb-3">My Posts</h5>
-    <div id="profile-feed" class="feed"></div>
-
-</div>
-
-<div class="col-lg-4">
-    <h5 class="mb-3">My Reviews</h5>
-
-    <div class="card p-3 mb-3">
-        <div class="d-flex justify-content-between mb-1">
-            <strong>Venn Coffee</strong>
-            <span style="color:var(--caramel);">
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star-fill"></i>
-            </span>
+            <h5 class="mb-3">My Posts</h5>
+            <div id="profile-feed" class="feed"></div>
         </div>
-        <p class="small text-muted mb-0">The oat flat white here is the gold standard for Subiaco.</p>
-    </div>
 
-    <div class="card p-3 mb-3">
-        <div class="d-flex justify-content-between mb-1">
-            <strong>Blacklist Coffee</strong>
-            <span style="color:var(--caramel);">
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star-fill"></i>
-                <i class="bi bi-star"></i>
-            </span>
+        <div class="col-lg-4">
+            <h5 class="mb-3">My Reviews</h5>
+            <div class="card p-3 mb-3">
+                <div class="d-flex justify-content-between mb-1">
+                    <strong>Venn Coffee</strong>
+                    <span style="color:var(--caramel);">
+                        <i class="bi bi-star-fill"></i><i class="bi bi-star-fill"></i>
+                        <i class="bi bi-star-fill"></i><i class="bi bi-star-fill"></i>
+                        <i class="bi bi-star-fill"></i>
+                    </span>
+                </div>
+                <p class="small text-muted mb-0">The oat flat white here is the gold standard for Subiaco.</p>
+                <a href="{{ url_for('shop_venn') }}" class="small mt-1 d-block" style="color:var(--caramel);">View shop</a>
+            </div>
+            <div class="card p-3 mb-3">
+                <div class="d-flex justify-content-between mb-1">
+                    <strong>Blacklist Coffee</strong>
+                    <span style="color:var(--caramel);">
+                        <i class="bi bi-star-fill"></i><i class="bi bi-star-fill"></i>
+                        <i class="bi bi-star-fill"></i><i class="bi bi-star-fill"></i>
+                        <i class="bi bi-star"></i>
+                    </span>
+                </div>
+                <p class="small text-muted mb-0">Best cold brew in Perth. Worth the drive to Welshpool.</p>
+                <a href="{{ url_for('shop_blacklist') }}" class="small mt-1 d-block" style="color:var(--caramel);">View shop</a>
+            </div>
         </div>
-        <p class="small text-muted mb-0">Best cold brew in Perth.</p>
     </div>
-</div>
-
-</div>
 </div>
 {% endblock %}
 
 {% block extra_js %}
-<script>
-const currentUser = {{ session.get('user', 'User')|tojson }};
-const avatarStorageKey = `profileAvatar:${currentUser}`;
-
-function getSavedAvatar() {
-    return localStorage.getItem(avatarStorageKey) || '';
-}
-
-function avatarMarkup(username, avatar) {
-    if (avatar) {
-        return `<img class="post-avatar-image" src="${avatar}" alt="${username} profile photo">`;
-    }
-
-    return `<div class="post-avatar-placeholder">${(username || 'U').charAt(0).toUpperCase()}</div>`;
-}
-
-function renderProfileAvatar() {
-    const avatar = getSavedAvatar();
-    const image = document.getElementById('profile-avatar-image');
-    const placeholder = document.getElementById('profile-avatar-placeholder');
-    const removeButton = document.getElementById('profile-avatar-remove');
-
-    if (avatar) {
-        image.src = avatar;
-        image.style.display = 'block';
-        placeholder.style.display = 'none';
-        removeButton.style.display = 'inline-block';
-    } else {
-        image.removeAttribute('src');
-        image.style.display = 'none';
-        placeholder.style.display = 'flex';
-        removeButton.style.display = 'none';
-    }
-}
-
-function handleAvatarUpload(event) {
-    const file = event.target.files[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = e => {
-        localStorage.setItem(avatarStorageKey, e.target.result);
-        syncUserPostAvatars(e.target.result);
-        if (window.updateNavbarAvatar) {
-            window.updateNavbarAvatar(e.target.result);
-        }
-        renderProfileAvatar();
-        loadProfilePosts();
-        event.target.value = '';
-    };
-    reader.readAsDataURL(file);
-}
-
-function removeProfileAvatar() {
-    if (!getSavedAvatar()) return;
-
-    localStorage.removeItem(avatarStorageKey);
-    syncUserPostAvatars('');
-
-    if (window.updateNavbarAvatar) {
-        window.updateNavbarAvatar('');
-    }
-
-    renderProfileAvatar();
-    loadProfilePosts();
-}
-
-function syncUserPostAvatars(avatar) {
-    const posts = JSON.parse(localStorage.getItem('posts')) || [];
-    const updatedPosts = posts.map(post => {
-        if (post.username === currentUser) {
-            return { ...post, avatar };
-        }
-        return post;
-    });
-
-    localStorage.setItem('posts', JSON.stringify(updatedPosts));
-}
-
-    <script>
-        window.currentUser = "{{ session.get('user', 'User') }}";
-    </script>
-
-    <script src="/static/js/social.js"></script>
-
-    <script>
-
-/* PREVIEW (same behavior as before) */
-    function previewProfileImage(event) {
-        const file = event.target.files[0];
-        if (!file) return;
-
-        const reader = new FileReader();
-
-        reader.onload = function(e) {
-            const img = document.getElementById("profile-image-preview");
-            const ratio = document.getElementById("aspect-ratio").value;
-
-            img.src = e.target.result;
-            img.style.display = "block";
-
-            if (ratio === "square") img.style.aspectRatio = "1 / 1";
-            else if (ratio === "portrait") img.style.aspectRatio = "4 / 5";
-            else if (ratio === "landscape") img.style.aspectRatio = "16 / 9";
-            else img.style.aspectRatio = "auto";
-        };
-
-        reader.readAsDataURL(file);
-    }
-
-/* CREATE POST — reuse social structure */
-function submitProfilePost() {
-    const text = document.getElementById('profile-post-text').value.trim();
-    const shop = document.getElementById('profile-post-shop').value;
-    const imageInput = document.getElementById('profile-post-image');
-
-    if (!text) { alert('Please write something!'); return; }
-
-    const reader = new FileReader();
-
-    reader.onload = function (e) {
-
-        const postData = {
-            username: currentUser,
-            owner: currentUser,
-            avatar: "https://i.pravatar.cc/40?u=" + currentUser,
-            text,
-            shop,
-            image: e.target.result,
-            avatar: getSavedAvatar(),
-            text: text,
-            shop: shop,
-            image: imageData || '',
-            likes: 0,
-            likedBy: [],
-            comments: [],
-            time: new Date().toISOString()
-        };
-
-        savePost(postData);   // 🔥 FROM social.js
-        loadProfilePosts();
-
-        document.getElementById('profile-post-text').value = '';
-        document.getElementById('profile-post-shop').value = '';
-        document.getElementById('profile-post-image').value = '';
-        document.getElementById('profile-image-preview').style.display = "none";
-    };
-
-    if (imageInput.files.length > 0) {
-        reader.readAsDataURL(imageInput.files[0]);
-    } else {
-        reader.onload({ target: { result: "" } });
-    }
-}
-
-/* 🔥 MAIN FIX — reuse social renderer */
-function loadProfilePosts() {
-    let posts = JSON.parse(localStorage.getItem("posts")) || [];
-
-    const myPosts = posts.filter(p => p.owner === currentUser);
-
-    const feed = document.getElementById("profile-feed");
-    feed.innerHTML = "";
-
-    if (myPosts.length === 0) {
-        feed.innerHTML = "<p class='text-muted'>No posts yet.</p>";
-        return;
-    }
-
-    // 🔥 TEMPORARILY hijack feed
-    const originalFeed = document.getElementById("feed");
-    feed.innerHTML = myPosts.map((p, i) => `
-        <div class="card mb-3 p-3">
-            <div class="profile-post-header">
-                ${avatarMarkup(p.username || currentUser, getSavedAvatar() || p.avatar)}
-                <div>
-                    <strong>${p.username || currentUser}</strong>
-                    <p class="small text-muted mb-0">${p.shop || ''}</p>
-                </div>
-            </div>
-            ${p.image ? `<img src="${p.image}" class="img-fluid rounded mb-2" style="max-height:300px;object-fit:cover;">` : ''}
-            <p class="mb-2">${p.text}</p>
-
-            <!-- Comments -->
-            <div class="comment-section mt-2">
-                ${(p.comments || []).map((c, ci) => `
-                    <div class="d-flex justify-content-between align-items-start mb-1">
-                        <p class="small mb-0"><strong>${c.username}</strong> ${c.text}</p>
-                        <button class="btn btn-sm p-0 ms-2" style="color:var(--caramel);font-size:0.75rem;"
-                            onclick="deleteProfileComment('${p.time}', ${ci})">Delete</button>
-                    </div>
-                `).join('')}
-                <input type="text" class="form-control form-control-sm mt-2"
-                    placeholder="Add a comment..."
-                    onkeypress="addProfileComment(event, '${p.time}', this)">
-            </div>
-        </div>
-    `).join('');
-}
-
-    const tempFeed = document.createElement("div");
-    tempFeed.id = "feed";
-    document.body.appendChild(tempFeed);
-
-    myPosts.forEach(post => renderPost(post));
-
-    feed.innerHTML = tempFeed.innerHTML;
-
-    tempFeed.remove();
-}
-
-
-/* INIT */
-window.onload = loadProfilePosts;
-
-</script>
-
-{% endblock %}
-document.getElementById('profile-avatar-upload').addEventListener('change', handleAvatarUpload);
-document.getElementById('profile-avatar-remove').addEventListener('click', removeProfileAvatar);
-
-window.onload = function() {
-    renderProfileAvatar();
-    loadProfilePosts();
-};
-</script>
+<script src="{{ url_for('static', filename='js/social.js') }}"></script>
+<script src="{{ url_for('static', filename='js/profile.js') }}"></script>
 {% endblock %}

--- a/templates/shop-blacklist.html
+++ b/templates/shop-blacklist.html
@@ -10,8 +10,8 @@
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
-        <a href="{{ url_for('brew') }}" class="shop-back-link">
-    <span class="shop-back-arrow">←</span> Back to Brew Map
+        <a href="{{ url_for('home') }}" class="shop-back-link">
+    <span class="shop-back-arrow">←</span> Back to Home
 </a>
         <div class="shop-hero-body">
             <div class="shop-identity">
@@ -163,9 +163,9 @@
                 </ul>
             </div>
 
-            <a href="{{ url_for('brew') }}" class="btn-primary-custom w-100 text-center d-block">
-                Back to Brew Map
-            </a>
+            <a href="{{ url_for('home') }}" class="btn-primary-custom w-100 text-center d-block">
+    Back to Home
+</a>
         </div>
     </div>
 </main>

--- a/templates/shop-harvest.html
+++ b/templates/shop-harvest.html
@@ -1,38 +1,37 @@
 {% extends 'base.html' %}
-{% block title %}La Veen Coffee | Coffee Social Hub{% endblock %}
+{% block title %}Harvest Espresso | Coffee Social Hub{% endblock %}
 
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
 {% endblock %}
 
 {% block content %}
-
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
         <a href="{{ url_for('home') }}" class="shop-back-link">
-    <span class="shop-back-arrow">←</span> Back to Home
-</a>
+            <span class="shop-back-arrow">←</span> Back to Home
+        </a>
         <div class="shop-hero-body">
             <div class="shop-identity">
-                <div class="shop-logo-badge">L</div>
+                <div class="shop-logo-badge">H</div>
                 <div>
                     <div class="shop-hero-tags">
+                        <span class="shop-badge">Cold Brew</span>
                         <span class="shop-badge">Pour Over</span>
-                        <span class="shop-badge">Dine-in</span>
                         <span class="shop-badge shop-badge--open">Open Now</span>
                     </div>
-                    <h1 class="shop-hero-title">La Veen Coffee</h1>
+                    <h1 class="shop-hero-title">Harvest Espresso</h1>
                     <p class="shop-hero-location">
-                        <i class="bi bi-geo-alt"></i> 79 King St, Perth WA 6000
+                        <i class="bi bi-geo-alt"></i> Leederville, Perth WA
                     </p>
                 </div>
             </div>
             <div class="shop-rating-pill">
-                <span class="rating-num">4.6</span>
+                <span class="rating-num">4.7</span>
                 <div>
-                    <div class="rating-stars">★★★★☆</div>
-                    <div class="rating-count">178 reviews</div>
+                    <div class="rating-stars">★★★★★</div>
+                    <div class="rating-count">180 reviews</div>
                 </div>
             </div>
         </div>
@@ -42,13 +41,12 @@
 <main class="container py-5">
     <div class="row g-5">
         <div class="col-lg-8">
-
             <div class="info-strip mb-5">
                 <div class="info-strip-item">
                     <i class="bi bi-clock" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Hours Today</div>
-                        <div class="info-strip-value">6:30 AM – 2:30 PM</div>
+                        <div class="info-strip-value">6:30 AM – 2:00 PM</div>
                     </div>
                 </div>
                 <div class="info-strip-item">
@@ -62,7 +60,7 @@
                     <i class="bi bi-p-square" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Parking</div>
-                        <div class="info-strip-value">Nearby paid parking</div>
+                        <div class="info-strip-value">Street parking</div>
                     </div>
                 </div>
             </div>
@@ -71,70 +69,52 @@
             <h2 class="section-title mb-4">Menu & Pricing</h2>
 
             <div class="menu-category mb-4">
-                <div class="menu-category-label">Pour Over Selection</div>
+                <div class="menu-category-label">Cold Brew</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Ethiopia Yirgacheffe</div>
-                        <div class="menu-item-desc">Floral, citrus, light body</div>
-                        <div class="menu-item-price">$8.00</div>
+                        <div class="menu-item-name">Cold Brew Black</div>
+                        <div class="menu-item-desc">Smooth 12-hour steep</div>
+                        <div class="menu-item-price">$5.50</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Colombia Huila</div>
-                        <div class="menu-item-desc">Caramel, stone fruit, medium body</div>
-                        <div class="menu-item-price">$8.50</div>
-                    </div>
-                    <div class="menu-item">
-                        <div class="menu-item-name">Kenya AA</div>
-                        <div class="menu-item-desc">Blackcurrant, tomato, bright acidity</div>
-                        <div class="menu-item-price">$9.00</div>
+                        <div class="menu-item-name">Cold Brew Oat Latte</div>
+                        <div class="menu-item-desc">Cold brew with oat milk</div>
+                        <div class="menu-item-price">$6.50</div>
                     </div>
                 </div>
             </div>
 
             <div class="menu-category mb-5">
-                <div class="menu-category-label">Espresso</div>
+                <div class="menu-category-label">Pour Over</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Latte</div>
-                        <div class="menu-item-desc">Smooth, full-bodied espresso</div>
-                        <div class="menu-item-price">$5.50</div>
+                        <div class="menu-item-name">V60 Pour Over</div>
+                        <div class="menu-item-desc">Single origin, bright notes</div>
+                        <div class="menu-item-price">$6.00</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Cappuccino</div>
-                        <div class="menu-item-desc">Classic dry foam style</div>
-                        <div class="menu-item-price">$5.00</div>
+                        <div class="menu-item-name">Chemex</div>
+                        <div class="menu-item-desc">Clean, balanced cup</div>
+                        <div class="menu-item-price">$7.00</div>
                     </div>
                 </div>
             </div>
 
             <span class="section-eyebrow">Community Takes</span>
             <h2 class="section-title mb-4">Ratings & Reviews</h2>
-
             <div class="review-list">
                 <div class="shop-review-card">
                     <div class="review-header">
-                        <div class="reviewer-avatar">M</div>
+                        <div class="reviewer-avatar">J</div>
                         <div>
-                            <div class="reviewer-name">MorningBrewMia</div>
-                            <div class="reviewer-date">1 day ago</div>
+                            <div class="reviewer-name">JavaJunkie</div>
+                            <div class="reviewer-date">2 days ago</div>
                         </div>
                         <div class="review-stars ms-auto">★★★★★</div>
                     </div>
-                    <p class="review-text">The Ethiopia pour over was extraordinary — floral and bright. The barista explained the origin and brewing method which made it even better.</p>
-                </div>
-                <div class="shop-review-card">
-                    <div class="review-header">
-                        <div class="reviewer-avatar">T</div>
-                        <div>
-                            <div class="reviewer-name">ThirdWaveTom</div>
-                            <div class="reviewer-date">4 days ago</div>
-                        </div>
-                        <div class="review-stars ms-auto">★★★★☆</div>
-                    </div>
-                    <p class="review-text">Excellent pour over selection, changes with the season. Right in the heart of the CBD — perfect for a pre-work coffee ritual.</p>
+                    <p class="review-text">Harvest is my go-to in Leederville. Their V60 is exceptional — clean and complex without being fussy.</p>
                 </div>
             </div>
-
         </div>
 
         <div class="col-lg-4">
@@ -151,35 +131,23 @@
                 <textarea class="review-textarea" placeholder="Share your experience…" rows="4"></textarea>
                 <button class="btn-primary-custom w-100 mt-3">Submit Review</button>
             </div>
-
             <div class="sidebar-card sidebar-card--dark mb-4">
                 <h3 class="sidebar-title sidebar-title--light">Quick Facts</h3>
                 <ul class="quick-facts-list">
-                    <li><i class="bi bi-cup"></i> Specialty pour over</li>
+                    <li><i class="bi bi-cup-hot"></i> Cold brew & pour over specialist</li>
                     <li><i class="bi bi-shop"></i> Dine-in available</li>
                     <li><i class="bi bi-bag"></i> Takeaway</li>
-                    <li><i class="bi bi-person-wheelchair"></i> Wheelchair accessible</li>
                     <li><i class="bi bi-credit-card"></i> Card and cash accepted</li>
                 </ul>
             </div>
-
             <a href="{{ url_for('home') }}" class="btn-primary-custom w-100 text-center d-block">
-    Back to Home
-</a>
+                Back to Home
+            </a>
         </div>
     </div>
 </main>
-
-<footer>
-    <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
-    </div>
-</footer>
-
 {% endblock %}
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/shop.js') }}"></script>
 {% endblock %}
-

--- a/templates/shop-marystreet.html
+++ b/templates/shop-marystreet.html
@@ -1,38 +1,36 @@
 {% extends 'base.html' %}
-{% block title %}La Veen Coffee | Coffee Social Hub{% endblock %}
+{% block title %}Mary Street Bakery | Coffee Social Hub{% endblock %}
 
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
 {% endblock %}
 
 {% block content %}
-
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
         <a href="{{ url_for('home') }}" class="shop-back-link">
-    <span class="shop-back-arrow">←</span> Back to Home
-</a>
+            <span class="shop-back-arrow">←</span> Back to Home
+        </a>
         <div class="shop-hero-body">
             <div class="shop-identity">
-                <div class="shop-logo-badge">L</div>
+                <div class="shop-logo-badge">M</div>
                 <div>
                     <div class="shop-hero-tags">
-                        <span class="shop-badge">Pour Over</span>
-                        <span class="shop-badge">Dine-in</span>
+                        <span class="shop-badge">Cold Brew</span>
                         <span class="shop-badge shop-badge--open">Open Now</span>
                     </div>
-                    <h1 class="shop-hero-title">La Veen Coffee</h1>
+                    <h1 class="shop-hero-title">Mary Street Bakery</h1>
                     <p class="shop-hero-location">
-                        <i class="bi bi-geo-alt"></i> 79 King St, Perth WA 6000
+                        <i class="bi bi-geo-alt"></i> Perth CBD, Perth WA
                     </p>
                 </div>
             </div>
             <div class="shop-rating-pill">
-                <span class="rating-num">4.6</span>
+                <span class="rating-num">4.4</span>
                 <div>
-                    <div class="rating-stars">★★★★☆</div>
-                    <div class="rating-count">178 reviews</div>
+                    <div class="rating-stars">★★★★★</div>
+                    <div class="rating-count">198 reviews</div>
                 </div>
             </div>
         </div>
@@ -42,13 +40,12 @@
 <main class="container py-5">
     <div class="row g-5">
         <div class="col-lg-8">
-
             <div class="info-strip mb-5">
                 <div class="info-strip-item">
                     <i class="bi bi-clock" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Hours Today</div>
-                        <div class="info-strip-value">6:30 AM – 2:30 PM</div>
+                        <div class="info-strip-value">7:00 AM – 3:00 PM</div>
                     </div>
                 </div>
                 <div class="info-strip-item">
@@ -62,7 +59,7 @@
                     <i class="bi bi-p-square" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Parking</div>
-                        <div class="info-strip-value">Nearby paid parking</div>
+                        <div class="info-strip-value">Nearby parking</div>
                     </div>
                 </div>
             </div>
@@ -71,70 +68,52 @@
             <h2 class="section-title mb-4">Menu & Pricing</h2>
 
             <div class="menu-category mb-4">
-                <div class="menu-category-label">Pour Over Selection</div>
+                <div class="menu-category-label">Cold Brew</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Ethiopia Yirgacheffe</div>
-                        <div class="menu-item-desc">Floral, citrus, light body</div>
-                        <div class="menu-item-price">$8.00</div>
+                        <div class="menu-item-name">Cold Brew Black</div>
+                        <div class="menu-item-desc">House cold brew, smooth finish</div>
+                        <div class="menu-item-price">$6.00</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Colombia Huila</div>
-                        <div class="menu-item-desc">Caramel, stone fruit, medium body</div>
-                        <div class="menu-item-price">$8.50</div>
-                    </div>
-                    <div class="menu-item">
-                        <div class="menu-item-name">Kenya AA</div>
-                        <div class="menu-item-desc">Blackcurrant, tomato, bright acidity</div>
-                        <div class="menu-item-price">$9.00</div>
+                        <div class="menu-item-name">Cold Brew Latte</div>
+                        <div class="menu-item-desc">With full cream or oat milk</div>
+                        <div class="menu-item-price">$7.00</div>
                     </div>
                 </div>
             </div>
 
             <div class="menu-category mb-5">
-                <div class="menu-category-label">Espresso</div>
+                <div class="menu-category-label">Bakery</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Latte</div>
-                        <div class="menu-item-desc">Smooth, full-bodied espresso</div>
-                        <div class="menu-item-price">$5.50</div>
+                        <div class="menu-item-name">Croissant</div>
+                        <div class="menu-item-desc">Butter, plain or almond</div>
+                        <div class="menu-item-price">$6.50</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Cappuccino</div>
-                        <div class="menu-item-desc">Classic dry foam style</div>
-                        <div class="menu-item-price">$5.00</div>
+                        <div class="menu-item-name">Cinnamon Scroll</div>
+                        <div class="menu-item-desc">Baked fresh daily</div>
+                        <div class="menu-item-price">$7.00</div>
                     </div>
                 </div>
             </div>
 
             <span class="section-eyebrow">Community Takes</span>
             <h2 class="section-title mb-4">Ratings & Reviews</h2>
-
             <div class="review-list">
                 <div class="shop-review-card">
                     <div class="review-header">
-                        <div class="reviewer-avatar">M</div>
+                        <div class="reviewer-avatar">L</div>
                         <div>
-                            <div class="reviewer-name">MorningBrewMia</div>
-                            <div class="reviewer-date">1 day ago</div>
+                            <div class="reviewer-name">LatteLover_Perth</div>
+                            <div class="reviewer-date">3 days ago</div>
                         </div>
                         <div class="review-stars ms-auto">★★★★★</div>
                     </div>
-                    <p class="review-text">The Ethiopia pour over was extraordinary — floral and bright. The barista explained the origin and brewing method which made it even better.</p>
-                </div>
-                <div class="shop-review-card">
-                    <div class="review-header">
-                        <div class="reviewer-avatar">T</div>
-                        <div>
-                            <div class="reviewer-name">ThirdWaveTom</div>
-                            <div class="reviewer-date">4 days ago</div>
-                        </div>
-                        <div class="review-stars ms-auto">★★★★☆</div>
-                    </div>
-                    <p class="review-text">Excellent pour over selection, changes with the season. Right in the heart of the CBD — perfect for a pre-work coffee ritual.</p>
+                    <p class="review-text">Mary Street is a Perth institution. The cinnamon scrolls with a cold brew is the perfect combo.</p>
                 </div>
             </div>
-
         </div>
 
         <div class="col-lg-4">
@@ -151,35 +130,24 @@
                 <textarea class="review-textarea" placeholder="Share your experience…" rows="4"></textarea>
                 <button class="btn-primary-custom w-100 mt-3">Submit Review</button>
             </div>
-
             <div class="sidebar-card sidebar-card--dark mb-4">
                 <h3 class="sidebar-title sidebar-title--light">Quick Facts</h3>
                 <ul class="quick-facts-list">
-                    <li><i class="bi bi-cup"></i> Specialty pour over</li>
+                    <li><i class="bi bi-cup-hot"></i> Cold brew specialist</li>
                     <li><i class="bi bi-shop"></i> Dine-in available</li>
                     <li><i class="bi bi-bag"></i> Takeaway</li>
-                    <li><i class="bi bi-person-wheelchair"></i> Wheelchair accessible</li>
+                    <li><i class="bi bi-basket"></i> Fresh bakery daily</li>
                     <li><i class="bi bi-credit-card"></i> Card and cash accepted</li>
                 </ul>
             </div>
-
             <a href="{{ url_for('home') }}" class="btn-primary-custom w-100 text-center d-block">
-    Back to Home
-</a>
+                Back to Home
+            </a>
         </div>
     </div>
 </main>
-
-<footer>
-    <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
-    </div>
-</footer>
-
 {% endblock %}
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/shop.js') }}"></script>
 {% endblock %}
-

--- a/templates/shop-satchmo.html
+++ b/templates/shop-satchmo.html
@@ -1,38 +1,36 @@
 {% extends 'base.html' %}
-{% block title %}La Veen Coffee | Coffee Social Hub{% endblock %}
+{% block title %}Satchmo | Coffee Social Hub{% endblock %}
 
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
 {% endblock %}
 
 {% block content %}
-
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
         <a href="{{ url_for('home') }}" class="shop-back-link">
-    <span class="shop-back-arrow">←</span> Back to Home
-</a>
+            <span class="shop-back-arrow">←</span> Back to Home
+        </a>
         <div class="shop-hero-body">
             <div class="shop-identity">
-                <div class="shop-logo-badge">L</div>
+                <div class="shop-logo-badge">S</div>
                 <div>
                     <div class="shop-hero-tags">
-                        <span class="shop-badge">Pour Over</span>
-                        <span class="shop-badge">Dine-in</span>
+                        <span class="shop-badge">Pet Friendly</span>
                         <span class="shop-badge shop-badge--open">Open Now</span>
                     </div>
-                    <h1 class="shop-hero-title">La Veen Coffee</h1>
+                    <h1 class="shop-hero-title">Satchmo</h1>
                     <p class="shop-hero-location">
-                        <i class="bi bi-geo-alt"></i> 79 King St, Perth WA 6000
+                        <i class="bi bi-geo-alt"></i> Mount Lawley, Perth WA
                     </p>
                 </div>
             </div>
             <div class="shop-rating-pill">
                 <span class="rating-num">4.6</span>
                 <div>
-                    <div class="rating-stars">★★★★☆</div>
-                    <div class="rating-count">178 reviews</div>
+                    <div class="rating-stars">★★★★★</div>
+                    <div class="rating-count">163 reviews</div>
                 </div>
             </div>
         </div>
@@ -42,13 +40,12 @@
 <main class="container py-5">
     <div class="row g-5">
         <div class="col-lg-8">
-
             <div class="info-strip mb-5">
                 <div class="info-strip-item">
                     <i class="bi bi-clock" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Hours Today</div>
-                        <div class="info-strip-value">6:30 AM – 2:30 PM</div>
+                        <div class="info-strip-value">7:00 AM – 3:00 PM</div>
                     </div>
                 </div>
                 <div class="info-strip-item">
@@ -62,7 +59,7 @@
                     <i class="bi bi-p-square" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Parking</div>
-                        <div class="info-strip-value">Nearby paid parking</div>
+                        <div class="info-strip-value">Street parking</div>
                     </div>
                 </div>
             </div>
@@ -71,70 +68,52 @@
             <h2 class="section-title mb-4">Menu & Pricing</h2>
 
             <div class="menu-category mb-4">
-                <div class="menu-category-label">Pour Over Selection</div>
+                <div class="menu-category-label">Espresso</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Ethiopia Yirgacheffe</div>
-                        <div class="menu-item-desc">Floral, citrus, light body</div>
-                        <div class="menu-item-price">$8.00</div>
+                        <div class="menu-item-name">Flat White</div>
+                        <div class="menu-item-desc">Signature house blend</div>
+                        <div class="menu-item-price">$5.00</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Colombia Huila</div>
-                        <div class="menu-item-desc">Caramel, stone fruit, medium body</div>
-                        <div class="menu-item-price">$8.50</div>
-                    </div>
-                    <div class="menu-item">
-                        <div class="menu-item-name">Kenya AA</div>
-                        <div class="menu-item-desc">Blackcurrant, tomato, bright acidity</div>
-                        <div class="menu-item-price">$9.00</div>
+                        <div class="menu-item-name">Cappuccino</div>
+                        <div class="menu-item-desc">Velvety foam, rich espresso</div>
+                        <div class="menu-item-price">$5.00</div>
                     </div>
                 </div>
             </div>
 
             <div class="menu-category mb-5">
-                <div class="menu-category-label">Espresso</div>
+                <div class="menu-category-label">All Day Bites</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Latte</div>
-                        <div class="menu-item-desc">Smooth, full-bodied espresso</div>
-                        <div class="menu-item-price">$5.50</div>
+                        <div class="menu-item-name">Banana Bread</div>
+                        <div class="menu-item-desc">Toasted, with ricotta</div>
+                        <div class="menu-item-price">$8.00</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Cappuccino</div>
-                        <div class="menu-item-desc">Classic dry foam style</div>
-                        <div class="menu-item-price">$5.00</div>
+                        <div class="menu-item-name">Avocado Toast</div>
+                        <div class="menu-item-desc">Sourdough, feta, chilli</div>
+                        <div class="menu-item-price">$14.00</div>
                     </div>
                 </div>
             </div>
 
             <span class="section-eyebrow">Community Takes</span>
             <h2 class="section-title mb-4">Ratings & Reviews</h2>
-
             <div class="review-list">
                 <div class="shop-review-card">
                     <div class="review-header">
                         <div class="reviewer-avatar">M</div>
                         <div>
-                            <div class="reviewer-name">MorningBrewMia</div>
-                            <div class="reviewer-date">1 day ago</div>
+                            <div class="reviewer-name">MorningMutt</div>
+                            <div class="reviewer-date">4 days ago</div>
                         </div>
                         <div class="review-stars ms-auto">★★★★★</div>
                     </div>
-                    <p class="review-text">The Ethiopia pour over was extraordinary — floral and bright. The barista explained the origin and brewing method which made it even better.</p>
-                </div>
-                <div class="shop-review-card">
-                    <div class="review-header">
-                        <div class="reviewer-avatar">T</div>
-                        <div>
-                            <div class="reviewer-name">ThirdWaveTom</div>
-                            <div class="reviewer-date">4 days ago</div>
-                        </div>
-                        <div class="review-stars ms-auto">★★★★☆</div>
-                    </div>
-                    <p class="review-text">Excellent pour over selection, changes with the season. Right in the heart of the CBD — perfect for a pre-work coffee ritual.</p>
+                    <p class="review-text">Brought my dog here on the weekend — huge outdoor area, super welcoming staff. Coffee was great too!</p>
                 </div>
             </div>
-
         </div>
 
         <div class="col-lg-4">
@@ -151,35 +130,24 @@
                 <textarea class="review-textarea" placeholder="Share your experience…" rows="4"></textarea>
                 <button class="btn-primary-custom w-100 mt-3">Submit Review</button>
             </div>
-
             <div class="sidebar-card sidebar-card--dark mb-4">
                 <h3 class="sidebar-title sidebar-title--light">Quick Facts</h3>
                 <ul class="quick-facts-list">
-                    <li><i class="bi bi-cup"></i> Specialty pour over</li>
+                    <li><i class="bi bi-cup-hot"></i> Espresso bar</li>
                     <li><i class="bi bi-shop"></i> Dine-in available</li>
                     <li><i class="bi bi-bag"></i> Takeaway</li>
-                    <li><i class="bi bi-person-wheelchair"></i> Wheelchair accessible</li>
+                    <li><i class="bi bi-heart"></i> Pet friendly outdoor area</li>
                     <li><i class="bi bi-credit-card"></i> Card and cash accepted</li>
                 </ul>
             </div>
-
             <a href="{{ url_for('home') }}" class="btn-primary-custom w-100 text-center d-block">
-    Back to Home
-</a>
+                Back to Home
+            </a>
         </div>
     </div>
 </main>
-
-<footer>
-    <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
-    </div>
-</footer>
-
 {% endblock %}
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/shop.js') }}"></script>
 {% endblock %}
-

--- a/templates/shop-telegram.html
+++ b/templates/shop-telegram.html
@@ -1,38 +1,36 @@
 {% extends 'base.html' %}
-{% block title %}La Veen Coffee | Coffee Social Hub{% endblock %}
+{% block title %}Telegram Cafe | Coffee Social Hub{% endblock %}
 
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/shop.css') }}">
 {% endblock %}
 
 {% block content %}
-
 <section class="hero-shop">
     <div class="hero-shop-bg-overlay"></div>
     <div class="container hero-shop-content">
         <a href="{{ url_for('home') }}" class="shop-back-link">
-    <span class="shop-back-arrow">←</span> Back to Home
-</a>
+            <span class="shop-back-arrow">←</span> Back to Home
+        </a>
         <div class="shop-hero-body">
             <div class="shop-identity">
-                <div class="shop-logo-badge">L</div>
+                <div class="shop-logo-badge">T</div>
                 <div>
                     <div class="shop-hero-tags">
                         <span class="shop-badge">Pour Over</span>
-                        <span class="shop-badge">Dine-in</span>
                         <span class="shop-badge shop-badge--open">Open Now</span>
                     </div>
-                    <h1 class="shop-hero-title">La Veen Coffee</h1>
+                    <h1 class="shop-hero-title">Telegram Cafe</h1>
                     <p class="shop-hero-location">
-                        <i class="bi bi-geo-alt"></i> 79 King St, Perth WA 6000
+                        <i class="bi bi-geo-alt"></i> Northbridge, Perth WA
                     </p>
                 </div>
             </div>
             <div class="shop-rating-pill">
-                <span class="rating-num">4.6</span>
+                <span class="rating-num">4.5</span>
                 <div>
-                    <div class="rating-stars">★★★★☆</div>
-                    <div class="rating-count">178 reviews</div>
+                    <div class="rating-stars">★★★★★</div>
+                    <div class="rating-count">142 reviews</div>
                 </div>
             </div>
         </div>
@@ -42,13 +40,12 @@
 <main class="container py-5">
     <div class="row g-5">
         <div class="col-lg-8">
-
             <div class="info-strip mb-5">
                 <div class="info-strip-item">
                     <i class="bi bi-clock" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Hours Today</div>
-                        <div class="info-strip-value">6:30 AM – 2:30 PM</div>
+                        <div class="info-strip-value">7:00 AM – 2:30 PM</div>
                     </div>
                 </div>
                 <div class="info-strip-item">
@@ -62,7 +59,7 @@
                     <i class="bi bi-p-square" style="font-size:1.3rem;color:var(--caramel)"></i>
                     <div>
                         <div class="info-strip-label">Parking</div>
-                        <div class="info-strip-value">Nearby paid parking</div>
+                        <div class="info-strip-value">Nearby parking</div>
                     </div>
                 </div>
             </div>
@@ -71,22 +68,17 @@
             <h2 class="section-title mb-4">Menu & Pricing</h2>
 
             <div class="menu-category mb-4">
-                <div class="menu-category-label">Pour Over Selection</div>
+                <div class="menu-category-label">Pour Over</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Ethiopia Yirgacheffe</div>
-                        <div class="menu-item-desc">Floral, citrus, light body</div>
-                        <div class="menu-item-price">$8.00</div>
+                        <div class="menu-item-name">V60 Single Origin</div>
+                        <div class="menu-item-desc">Rotating seasonal beans</div>
+                        <div class="menu-item-price">$6.50</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Colombia Huila</div>
-                        <div class="menu-item-desc">Caramel, stone fruit, medium body</div>
-                        <div class="menu-item-price">$8.50</div>
-                    </div>
-                    <div class="menu-item">
-                        <div class="menu-item-name">Kenya AA</div>
-                        <div class="menu-item-desc">Blackcurrant, tomato, bright acidity</div>
-                        <div class="menu-item-price">$9.00</div>
+                        <div class="menu-item-name">Kalita Wave</div>
+                        <div class="menu-item-desc">Balanced, smooth extraction</div>
+                        <div class="menu-item-price">$6.50</div>
                     </div>
                 </div>
             </div>
@@ -95,46 +87,33 @@
                 <div class="menu-category-label">Espresso</div>
                 <div class="menu-grid">
                     <div class="menu-item">
-                        <div class="menu-item-name">Latte</div>
-                        <div class="menu-item-desc">Smooth, full-bodied espresso</div>
-                        <div class="menu-item-price">$5.50</div>
+                        <div class="menu-item-name">Flat White</div>
+                        <div class="menu-item-desc">House blend, silky milk</div>
+                        <div class="menu-item-price">$5.00</div>
                     </div>
                     <div class="menu-item">
-                        <div class="menu-item-name">Cappuccino</div>
-                        <div class="menu-item-desc">Classic dry foam style</div>
-                        <div class="menu-item-price">$5.00</div>
+                        <div class="menu-item-name">Latte</div>
+                        <div class="menu-item-desc">Classic and comforting</div>
+                        <div class="menu-item-price">$5.50</div>
                     </div>
                 </div>
             </div>
 
             <span class="section-eyebrow">Community Takes</span>
             <h2 class="section-title mb-4">Ratings & Reviews</h2>
-
             <div class="review-list">
                 <div class="shop-review-card">
                     <div class="review-header">
-                        <div class="reviewer-avatar">M</div>
+                        <div class="reviewer-avatar">S</div>
                         <div>
-                            <div class="reviewer-name">MorningBrewMia</div>
-                            <div class="reviewer-date">1 day ago</div>
+                            <div class="reviewer-name">SipAndWork</div>
+                            <div class="reviewer-date">1 week ago</div>
                         </div>
                         <div class="review-stars ms-auto">★★★★★</div>
                     </div>
-                    <p class="review-text">The Ethiopia pour over was extraordinary — floral and bright. The barista explained the origin and brewing method which made it even better.</p>
-                </div>
-                <div class="shop-review-card">
-                    <div class="review-header">
-                        <div class="reviewer-avatar">T</div>
-                        <div>
-                            <div class="reviewer-name">ThirdWaveTom</div>
-                            <div class="reviewer-date">4 days ago</div>
-                        </div>
-                        <div class="review-stars ms-auto">★★★★☆</div>
-                    </div>
-                    <p class="review-text">Excellent pour over selection, changes with the season. Right in the heart of the CBD — perfect for a pre-work coffee ritual.</p>
+                    <p class="review-text">Love the vibe here in Northbridge. The pour over selection rotates weekly — always something new to try.</p>
                 </div>
             </div>
-
         </div>
 
         <div class="col-lg-4">
@@ -151,35 +130,23 @@
                 <textarea class="review-textarea" placeholder="Share your experience…" rows="4"></textarea>
                 <button class="btn-primary-custom w-100 mt-3">Submit Review</button>
             </div>
-
             <div class="sidebar-card sidebar-card--dark mb-4">
                 <h3 class="sidebar-title sidebar-title--light">Quick Facts</h3>
                 <ul class="quick-facts-list">
-                    <li><i class="bi bi-cup"></i> Specialty pour over</li>
+                    <li><i class="bi bi-cup-hot"></i> Pour over specialist</li>
                     <li><i class="bi bi-shop"></i> Dine-in available</li>
                     <li><i class="bi bi-bag"></i> Takeaway</li>
-                    <li><i class="bi bi-person-wheelchair"></i> Wheelchair accessible</li>
                     <li><i class="bi bi-credit-card"></i> Card and cash accepted</li>
                 </ul>
             </div>
-
             <a href="{{ url_for('home') }}" class="btn-primary-custom w-100 text-center d-block">
-    Back to Home
-</a>
+                Back to Home
+            </a>
         </div>
     </div>
 </main>
-
-<footer>
-    <div class="container d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <span class="footer-brand">Coffee Social Hub</span>
-        <span class="footer-note">CITS5505 Group Project · UWA 2026</span>
-    </div>
-</footer>
-
 {% endblock %}
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/shop.js') }}"></script>
 {% endblock %}
-


### PR DESCRIPTION
- Extracted all inline JS into separate files (delete.js, navbar.js, profile.js)
- Fixed stray HTML syntax error in social.js
- Added missing previewImage function to social.js
- Fixed extra > typo in home.html breaking currentUser (closes #36)
- Fixed mismatched Jinja block tags in profile.html (closes #37)
- Added full detail pages for Harvest, Telegram, Satchmo, Mary Street
- Fixed route: None for 4 new cafes in app.py
- Updated all shop back links to point to home instead of brew