### PR TITLE
feat: add onboarding tour modal for first-time users

### DIFF
--- a/static/css/home.css
+++ b/static/css/home.css
@@ -95,3 +95,103 @@
 .brew-grid .btn-outline-nav {
     margin-top: auto !important;
 }
+
+/* ── ONBOARDING TOUR MODAL ──────────────────────────────── */
+.onboarding-modal-content {
+    background: var(--cream);
+    border: none;
+    border-radius: 20px;
+    padding: 2.5rem 2rem 1.5rem;
+    box-shadow: var(--shadow-lg);
+    text-align: center;
+}
+
+.onboarding-step {
+    min-height: 180px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.onboarding-icon {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--caramel), var(--roast));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1.25rem;
+    font-size: 2rem;
+    color: #fff;
+}
+
+.onboarding-title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.6rem;
+    color: var(--espresso);
+    margin-bottom: 0.75rem;
+}
+
+.onboarding-desc {
+    color: var(--muted);
+    font-size: 1rem;
+    line-height: 1.6;
+    max-width: 320px;
+    margin: 0 auto;
+}
+
+.onboarding-dots {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin: 1.5rem 0 1rem;
+}
+
+.onboarding-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--latte);
+    transition: all 0.25s ease;
+}
+
+.onboarding-dot.active {
+    width: 24px;
+    border-radius: 4px;
+    background: var(--caramel);
+}
+
+.onboarding-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 0.5rem;
+}
+
+.btn-onboarding-skip {
+    color: var(--muted);
+    background: none;
+    border: none;
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: color 0.2s;
+}
+.btn-onboarding-skip:hover { color: var(--espresso); }
+
+.btn-onboarding-next {
+    background: var(--caramel);
+    color: #fff;
+    border: none;
+    padding: 0.6rem 1.4rem;
+    border-radius: 10px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: background 0.2s, color 0.2s;
+}
+.btn-onboarding-next:hover {
+    background: var(--roast);
+    color: var(--latte);
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -106,6 +106,56 @@
     </div>
 
 </div>
+<!-- ── Onboarding Tour Modal ─────────────────────────────── -->
+<div class="modal fade" id="onboardingModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="onboardingModalLabel" aria-modal="true" role="dialog">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content onboarding-modal-content">
+
+            <!-- Step 1: Welcome -->
+            <div class="onboarding-step" id="onboarding-step-1">
+                <div class="onboarding-icon">
+                    <i class="bi bi-geo-alt-fill"></i>
+                </div>
+                <h4 class="onboarding-title" id="onboardingModalLabel">Discover Perth Cafes</h4>
+                <p class="onboarding-desc">Welcome! Explore the Brew Map to find the best coffee spots around Perth — filtered by your vibe.</p>
+            </div>
+
+            <!-- Step 2: Share -->
+            <div class="onboarding-step d-none" id="onboarding-step-2">
+                <div class="onboarding-icon">
+                    <i class="bi bi-camera-fill"></i>
+                </div>
+                <h4 class="onboarding-title">Post Your Coffee Moments</h4>
+                <p class="onboarding-desc">Tap the <strong>+</strong> button to share a photo or thought from your latest cafe visit. Tag the shop to earn kudos.</p>
+            </div>
+
+            <!-- Step 3: Connect -->
+            <div class="onboarding-step d-none" id="onboarding-step-3">
+                <div class="onboarding-icon">
+                    <i class="bi bi-heart-fill"></i>
+                </div>
+                <h4 class="onboarding-title">Like &amp; Comment on Posts</h4>
+                <p class="onboarding-desc">Connect with fellow Perth coffee lovers — like their moments and join the conversation.</p>
+            </div>
+
+            <!-- Progress dots -->
+            <div class="onboarding-dots" aria-hidden="true">
+                <span class="onboarding-dot active" id="onboarding-dot-1"></span>
+                <span class="onboarding-dot" id="onboarding-dot-2"></span>
+                <span class="onboarding-dot" id="onboarding-dot-3"></span>
+            </div>
+
+            <!-- Navigation buttons -->
+            <div class="onboarding-actions">
+                <button class="btn-onboarding-skip" id="onboarding-skip" type="button">Skip</button>
+                <button class="btn-onboarding-next" id="onboarding-next" type="button">
+                    Next <i class="bi bi-arrow-right"></i>
+                </button>
+            </div>
+
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}
@@ -114,4 +164,48 @@
 </script>
 <script src="{{ url_for('static', filename='js/social.js') }}"></script>
 <script src="{{ url_for('static', filename='js/brew.js') }}"></script>
+<script>
+(function () {
+    const user = window.currentUser;
+    if (!user) return;
+
+    const STORAGE_KEY = 'coffee_onboarding_seen_' + user;
+    if (localStorage.getItem(STORAGE_KEY)) return;
+
+    const TOTAL_STEPS = 3;
+    let currentStep = 1;
+
+    const bsModal = new bootstrap.Modal(document.getElementById('onboardingModal'));
+    bsModal.show();
+
+    function goToStep(next) {
+        document.getElementById('onboarding-step-' + currentStep).classList.add('d-none');
+        document.getElementById('onboarding-dot-' + currentStep).classList.remove('active');
+        currentStep = next;
+        document.getElementById('onboarding-step-' + currentStep).classList.remove('d-none');
+        document.getElementById('onboarding-dot-' + currentStep).classList.add('active');
+
+        const nextBtn = document.getElementById('onboarding-next');
+        if (currentStep === TOTAL_STEPS) {
+            nextBtn.innerHTML = 'Got it! <i class="bi bi-check-lg"></i>';
+        } else {
+            nextBtn.innerHTML = 'Next <i class="bi bi-arrow-right"></i>';
+        }
+    }
+
+    function finishTour() {
+        localStorage.setItem(STORAGE_KEY, '1');
+        bsModal.hide();
+    }
+
+    document.getElementById('onboarding-skip').addEventListener('click', finishTour);
+    document.getElementById('onboarding-next').addEventListener('click', function () {
+        if (currentStep < TOTAL_STEPS) {
+            goToStep(currentStep + 1);
+        } else {
+            finishTour();
+        }
+    });
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Add a 3-step onboarding Bootstrap modal that auto-shows on first login to `/home`
- Steps cover the three core app features: Discover Perth cafes → Share coffee moments → Like & comment on posts
- localStorage flag (`coffee_onboarding_seen_<username>`) prevents the modal from re-appearing on subsequent visits, scoped per username so each account gets the tour once
- Skip button dismisses at any step; Next advances through steps; final step shows "Got it!" to close

## Changes

- `templates/home.html` — onboarding modal HTML (3 steps, progress dots, Skip/Next buttons) + inline JS for step navigation and localStorage logic
- `static/css/home.css` — `.onboarding-*` styles using existing design tokens (colour variables, fonts, border-radius)

## Test plan

- [x] Log in as a new/existing user → modal appears automatically on `/home`
- [ ] Click Next through all 3 steps — dot indicator updates and button changes to "Got it!" on step 3
- [ ] Click "Got it!" → modal closes and does not reappear on refresh or re-login
- [ ] Open DevTools → Application → Local Storage → delete `coffee_onboarding_seen_<username>` → refresh → modal reappears
- [ ] Click Skip on any step → modal closes immediately and flag is set
- [ ] Log in as a second user account → modal shows again (separate localStorage key)
- [ ] Test on mobile viewport (≤ 375px) — modal is centered and readable
