### PR TITLE
test: Added flask route unit tests with pytest

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,87 @@
+import pytest
+from app import app, db
+from models import User
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['WTF_CSRF_ENABLED'] = False
+
+    with app.test_client() as client:
+        with app.app_context():
+            db.create_all()
+            yield client
+            db.session.remove()
+            db.drop_all()
+
+
+def test_login_page_loads(client):
+    response = client.get('/login')
+    assert response.status_code == 200
+
+def test_home_redirects_when_not_logged_in(client):
+    response = client.get('/home')
+    assert response.status_code == 302
+
+def test_signup_creates_user(client):
+    response = client.post('/signup', data={
+        'username': 'testuser',
+        'password': 'testpass',
+        'confirm_password': 'testpass'
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+
+def test_login_valid_credentials(client):
+
+    client.post('/signup', data={
+        'username': 'testuser',
+        'password': 'testpass',
+        'confirm_password': 'testpass'
+    })
+
+    response = client.post('/login', data={
+        'username': 'testuser',
+        'password': 'testpass'
+    }, follow_redirects=False)
+
+    assert response.status_code == 302
+
+def test_login_invalid_credentials(client):
+
+    response = client.post('/login', data={
+        'username': 'wronguser',
+        'password': 'wrongpass'
+    }, follow_redirects=True)
+
+    assert b"Invalid username or password" in response.data
+
+def test_logout_redirects_to_login(client):
+
+    client.post('/signup', data={
+        'username': 'testuser',
+        'password': 'testpass',
+        'confirm_password': 'testpass'
+    })
+
+    client.post('/login', data={
+        'username': 'testuser',
+        'password': 'testpass'
+    })
+
+    response = client.get('/logout', follow_redirects=False)
+
+    assert response.status_code == 302
+
+def test_api_posts_requires_login(client):
+
+    response = client.get('/api/posts')
+
+    assert response.status_code == 401
+
+def test_api_avatar_requires_login(client):
+
+    response = client.post('/api/avatar')
+
+    assert response.status_code == 401


### PR DESCRIPTION
Added Flask route unit tests using pytest and Flask test client.

Changes in this PR:
- Created `tests/` folder with `__init__.py`
- Added `tests/test_routes.py`
- Configured tests to use in-memory SQLite database
- Implemented route tests for authentication and protected API endpoints

Tests added:
1. Home page redirects when not authenticated
2. Login page loads successfully (GET)
3. Signup with valid credentials creates user
4. Login with valid credentials returns 302 redirect
5. Login with invalid credentials returns error
6. Logout redirects to login page
7. `/api/posts` returns 401 when not logged in
8. `/api/avatar` returns 401 when not logged in

Testing done:
- Ran `python -m pytest tests/test_routes.py -v`
- All tests passing successfully